### PR TITLE
feat(model): implement confidence intervals

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ numpy = "*"
 matplotlib = "*"
 scipy = "*"
 jupyter = "*"
+sklearn = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "007929afceb879ba8e55ebe0a780dcc7902329281b52e18eecdefdf89d8e9cda"
+            "sha256": "6991db8b4e72c3238e04cc4a6e0470a795a90a242509cdce85b4526cd9c582f1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,14 +16,6 @@
         ]
     },
     "default": {
-        "appnope": {
-            "hashes": [
-                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
-                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
-            ],
-            "markers": "platform_system == 'Darwin'",
-            "version": "==0.1.0"
-        },
         "attrs": {
             "hashes": [
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
@@ -122,6 +114,13 @@
                 "sha256:c922560ac46888d47384de1dbdc3daaa2ea993af4b26a436dec31fa2c19ec668"
             ],
             "version": "==3.0.0a1"
+        },
+        "joblib": {
+            "hashes": [
+                "sha256:0630eea4f5664c463f23fbf5dcfc54a2bc6168902719fa8e19daf033022786c8",
+                "sha256:bdb4fd9b72915ffb49fde2229ce482dd7ae79d842ed8c2b4c932441495af1403"
+            ],
+            "version": "==0.14.1"
         },
         "jsonschema": {
             "hashes": [
@@ -424,6 +423,32 @@
             ],
             "version": "==1.9.0"
         },
+        "scikit-learn": {
+            "hashes": [
+                "sha256:1bf45e62799b6938357cfce19f72e3751448c4b27010e4f98553da669b5bbd86",
+                "sha256:267ad874b54c67b479c3b45eb132ef4a56ab2b27963410624a413a4e2a3fc388",
+                "sha256:2d1bb83d6c51a81193d8a6b5f31930e2959c0e1019d49bdd03f54163735dae4b",
+                "sha256:349ba3d837fb3f7cb2b91486c43713e4b7de17f9e852f165049b1b7ac2f81478",
+                "sha256:3f4d8eea3531d3eaf613fa33f711113dfff6021d57a49c9d319af4afb46f72f0",
+                "sha256:4990f0e166292d2a0f0ee528233723bcfd238bfdb3ec2512a9e27f5695362f35",
+                "sha256:57538d138ba54407d21e27c306735cbd42a6aae0df6a5a30c7a6edde46b0017d",
+                "sha256:5b722e8bb708f254af028dc2da86d23df5371cba57e24f889b672e7b15423caa",
+                "sha256:6043e2c4ccfc68328c331b0fc19691be8fb02bd76d694704843a23ad651de902",
+                "sha256:672ea38eb59b739a8907ec063642b486bcb5a2073dda5b72b7983eeaf1fd67c1",
+                "sha256:73207dca6e70f8f611f28add185cf3a793c8232a1722f21d82259560dc35cd50",
+                "sha256:83fc104a799cb340054e485c25dfeee712b36f5638fb374eba45a9db490f16ff",
+                "sha256:8416150ab505f1813da02cdbdd9f367b05bfc75cf251235015bb09f8674358a0",
+                "sha256:84e759a766c315deb5c85139ff879edbb0aabcddb9358acf499564ed1c21e337",
+                "sha256:8ed66ab27b3d68e57bb1f315fc35e595a5c4a1f108c3420943de4d18fc40e615",
+                "sha256:a7f8aa93f61aaad080b29a9018db93ded0586692c03ddf2122e47dd1d3a14e1b",
+                "sha256:ddd3bf82977908ff69303115dd5697606e669d8a7eafd7d83bb153ef9e11bd5e",
+                "sha256:de9933297f8659ee3bb330eafdd80d74cd73d5dab39a9026b65a4156bc479063",
+                "sha256:ea91a70a992ada395efc3d510cf011dc2d99dc9037bb38cd1cb00e14745005f5",
+                "sha256:eb4c9f0019abb374a2e55150f070a333c8f990b850d1eb4dfc2765fc317ffc7c",
+                "sha256:ffce8abfdcd459e72e5b91727b247b401b22253cbd18d251f842a60e26262d6f"
+            ],
+            "version": "==0.22.2.post1"
+        },
         "scipy": {
             "hashes": [
                 "sha256:00af72998a46c25bdb5824d2b729e7dabec0c765f9deb0b504f928591f5ff9d4",
@@ -464,6 +489,13 @@
                 "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
             "version": "==1.14.0"
+        },
+        "sklearn": {
+            "hashes": [
+                "sha256:e23001573aa194b834122d2b9562459bf5ae494a2d59ca6b8aa22c85a44c0e31"
+            ],
+            "index": "pypi",
+            "version": "==0.0"
         },
         "terminado": {
             "hashes": [

--- a/SIR-X.ipynb
+++ b/SIR-X.ipynb
@@ -39,9 +39,7 @@
     "\n",
     "In early stages of the infection, the number of infected people is much lower than the susceptible populations. Hence, $S \\approx 1$ making $dI/dt$ linear and the system has the analytical solution $I(t) = I_0 \\exp (\\alpha - \\beta)t$.\n",
     "\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -50,9 +48,7 @@
     "#### Numerical implementation - SIR model\n",
     "\n",
     "Three python packages are imported: numpy for numerical computing, matplotlib.pyplot for visualization and the numerical integration routine odeint from scipy.integrate:"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
@@ -84,9 +80,7 @@
     "So $\\vec{f} = \\text{sir}(\\vec{w}, t, \\vec{p})$.\n",
     "\n",
     "The solution of this system is a vector field $\\vec{w} = [S(t),I(t),R(t)]$. In day to day words, it gives the percentage of the population who are susceptible (S), infected (I) and recovered or removed R(t) as a function of time. There is no analytical solution for this system. However, a numerical solution can be obtained using a numerical integrator. In this implementation, the function scipy.odeint is used to integrate the differential system. The ODE system of the SIR model was implemented in the function sirx(t,w,p) on the module model.py. The solver is implemented in the function _solve on the module model.py.\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -97,81 +91,6 @@
     "A new epidemic model based in SIR, SIRX, was developed by the [Robert Koch Institut](http://rocs.hu-berlin.de/corona/docs/forecast/model/#sir-x-dynamics-outbreaks-with-temporally-increasing-interventions) and is implemented in what follows. A full description of the model is available in the [Robert Koch Institut SIRX model webiste](http://rocs.hu-berlin.de/corona/docs/forecast/model/#sir-x-dynamics-outbreaks-with-temporally-increasing-interventions).\n",
     "\n",
     "The ODE system of the SIR-X model was implemented in the function sirx(t,w,p) on the module model.py"
-   ],
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import model\n",
-    "from model import _solve #?\n",
-    "\n",
-    "class Model:\n",
-    "    \n",
-    "    def __init__(self, p, w0):\n",
-    "        self.setmodel()\n",
-    "        self.p = p\n",
-    "        self.w0 = w0\n",
-    "        \n",
-    "    \n",
-    "    def solve(self, tf_secs, numpoints):\n",
-    "        tspan = np.linspace(0,tf_secs,numpoints)\n",
-    "        \n",
-    "        a = _solve(self.func, self.p, self.w0,\n",
-    "                     tspan, numpoints)\n",
-    "        return a\n",
-    "    \n",
-    "    @property\n",
-    "    def R_0(self):\n",
-    "        \"\"\" Returns reproduction number\n",
-    "        R_0 = alpha/beta\"\"\"\n",
-    "        return self.p[0]/self.p[1]\n",
-    "    \n",
-    "    def fit(self, t_obs, n_I_obs, population, inplace=False):\n",
-    "        \"\"\" Use the Levenberg-Marquardt algorithm to fit\n",
-    "        the parameter alpha, as beta is assumed constant\n",
-    "        \n",
-    "        inputs:\n",
-    "        t_obs: Vector of days corresponding to the observations of number of infected people\n",
-    "        n_I_obs: Vector of number of infected people\n",
-    "        population: Size of the objective population\n",
-    "        \n",
-    "        Returns\n",
-    "        \"\"\"\n",
-    "        \n",
-    "        secs_obs = t_obs*3600*24\n",
-    "        \n",
-    "        def function_handle(t, alpha, beta = self.p[1], population=population):\n",
-    "            p = [alpha,beta]\n",
-    "            I_mod = _solve(self.func, p, self.w0,\n",
-    "                           t, numpoints=len(t_obs))\n",
-    "            n_I_mod = I_mod[:,2]*population\n",
-    "            return n_I_mod\n",
-    "        \n",
-    "        # Fit alpha\n",
-    "        alpha_opt, pcov = curve_fit(f = function_handle,\n",
-    "                        xdata = secs_obs, ydata = n_I_obs, p0=self.p[0])\n",
-    "        p_new = [i for i in self.p] \n",
-    "        p_new[0] = alpha_opt[0]\n",
-    "        self.p=p_new\n",
-    "        return \n",
-    "        # return p_new, pcov\n",
-    "            \n",
-    "    pass\n",
-    "\n",
-    "class SIR(Model):\n",
-    "    def setmodel(self):\n",
-    "        self.func = model.sir\n",
-    "    pass\n",
-    "\n",
-    "class SIRX(Model):\n",
-    "    def setmodel(self):\n",
-    "        self.func = model.sirx\n",
-    "    pass"
    ]
   },
   {
@@ -192,9 +111,7 @@
     "The reproduction number is fixed $R_0 = \\alpha / \\beta = 2.5$ as a first approximation. \n",
     "\n",
     "Please note that the predictions of this model shouldn't be taken in consideratin, as the SIR model doesn't consider dynamic variation of model parameters, which is observed in reality."
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -202,9 +119,7 @@
    "source": [
     "### Solution and implementation\n",
     "The aim of this API is to provide an user friendly approach to build a SIR model and fit it to a target dataset in order to make predictions in few lines of code.\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
@@ -221,7 +136,7 @@
     "n_days = len(Ealing_data)\n",
     "\n",
     "# Input parameters\n",
-    "beta = 0.38/(3600*24) # Per day\n",
+    "beta = 0.38 # Per day\n",
     "alpha = 2.5 * beta # WHO estimate"
    ]
   },
@@ -230,9 +145,7 @@
    "metadata": {},
    "source": [
     "#### Calculate model parameters and initial conditions"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
@@ -240,26 +153,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Calculate initial conditions in terms of population fraction\n",
-    "S0 = (P_Ealing-I_Ealing)/P_Ealing\n",
-    "I0 = I_Ealing/P_Ealing\n",
-    "R0 = R_Ealing/P_Ealing      # Recovered people\n",
+    "# Calculate initial conditions in terms of total number of individuals\n",
+    "S0 = (P_Ealing-I_Ealing)\n",
+    "I0 = I_Ealing\n",
+    "R0 = R_Ealing    # Recovered people\n",
     "\n",
     "# Construct vector of parameters\n",
-    "p = [alpha, beta]\n",
+    "params = [alpha, beta]\n",
     "\n",
     "# Construct vector of initial conditions\n",
-    "w0 = [S0, I0, R0]\n",
-    "\n",
-    "# ODE solver parameters (optional)\n",
-    "abserr = 1.0e-8  #\n",
-    "relerr = 1.0e-6  #\n",
-    "\n",
-    "tf = 3600*24*(n_days-1)   # Final time in seconds\n",
-    "numpoints = n_days #\n",
-    "\n",
-    "# Create time vector to input to the integrator odeint\n",
-    "t = np.linspace(0, tf,numpoints)"
+    "w0 = [S0, I0, R0]"
    ]
   },
   {
@@ -267,9 +170,7 @@
    "metadata": {},
    "source": [
     "### Build the model with the default parameters and predict the number of susceptible, infected and recovered people in the Ealing borough."
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
@@ -277,23 +178,38 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Build a SIR model\n",
-    "my_SIR = SIR(p,w0)\n",
-    "# Call model.solve functions with the time in seconds (tf) and the number of points where the solution will be evaluated\n",
-    "sol = my_SIR.solve(tf,numpoints)\n",
+    "from model import SIR, SIRX"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize an emplty SIR model\n",
+    "my_SIR = SIR()\n",
+    "# Set model parameters\n",
+    "my_SIR._set_params(p=params,initial_conds=w0)\n",
+    "\n",
+    "# Call model.solve functions with the time in days and the number of points\n",
+    "# as the number of days\n",
+    "my_SIR.solve(n_days-1, n_days)\n",
+    "# Unpack the numerical solution using the model.fetch() method\n",
+    "sol = my_SIR.fetch()\n",
     "# Unpack the numerical solution for the susceptible (S), infected (I) and recovered or removed (R)\n",
     "S_sir = sol[:,1]\n",
     "I_sir = sol[:,2]\n",
     "R_sir = sol[:,3]\n",
-    "# Convert the ratio to population\n",
-    "N_I_sir = I_sir*P_Ealing\n",
     "# Plot the results\n",
-    "# Define array of days\n",
+    "# Define array of days. Note that the initial day is the day \"zero\", so \n",
+    "# the final day is the number of days minus one. This is divided in n_days\n",
+    "# intervals to be consistent with the input\n",
     "days_list = np.linspace(0, n_days-1, n_days)\n",
-    "plt.plot(days_list, N_I_sir)\n",
+    "plt.plot(days_list, I_sir)\n",
     "plt.plot(days_list, Ealing_data,'bo')\n",
     "plt.show()\n",
-    "my_SIR.R_0"
+    "my_SIR.r0"
    ]
   },
   {
@@ -306,9 +222,7 @@
     "\n",
     "\n",
     "The function model.fit() enables to fit the desired parameters to a certain dataset. The parameter fitting is straightforward using open-sir:"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -318,9 +232,16 @@
     "Fitting $R_0$ through $\\alpha$ keeping $\\beta$ constant\n",
     "\n",
     "In the following case study, $R_0$ will be fitted to minimize the mean squared error between the model predictions and UK historical data on the Ealing borough in the time period between the 15th and the 29th of March of 2020."
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
-   "outputs": []
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ealing_data"
+   ]
   },
   {
    "cell_type": "code",
@@ -329,20 +250,41 @@
    "outputs": [],
    "source": [
     "# Create SIR with default parameters\n",
-    "my_SIR_fitted = SIR(p,w0)\n",
-    "# Create a vector of times\n",
-    "# t = np.linspace(0, tf,numpoints)\n",
+    "my_SIR_fitted = SIR()\n",
+    "my_SIR_fitted.set_params(params,w0)\n",
+    "\n",
     "# Fit parameters\n",
-    "w = my_SIR_fitted.fit(days_list, Ealing_data, P_Ealing)\n",
+    "w = my_SIR_fitted.fit(days_list, Ealing_data, P_Ealing, fit_index=[True,False])\n",
     "# Print the fitted reproduction rate\n",
-    "print(\"Fitted reproduction rate R_0 = %.2f\" % my_SIR_fitted.R_0)\n",
+    "print(\"Fitted reproduction rate R_0 = %.2f\" % my_SIR_fitted.r0)\n",
     "# Build the new solution\n",
-    "sol = my_SIR_fitted.solve(tf, numpoints)\n",
+    "my_SIR_fitted.solve(n_days-1, n_days)\n",
+    "# Extract solution\n",
+    "sol = my_SIR_fitted.fetch()\n",
     "# Plot the results\n",
     "\n",
-    "plt.plot(days_list,sol[:,2]*P_Ealing)\n",
+    "plt.plot(days_list,sol[:,2])\n",
     "plt.plot(days_list,Ealing_data,'bo')\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_SIR_fitted.r0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_SIR_fitted.p[[False,True]]\n",
+    "my_SIR"
    ]
   },
   {
@@ -353,16 +295,12 @@
     "### Example: predict the total number of infections and the time where the number of infected people is maximum\n",
     "\n",
     "This is extremely dangerous as $R_0$ is extremely likely to change with time. However we have seen many people taking decisions in this kind of analysis. Use it at your own risk and with a metric ton of salt."
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [],
-   "execution_count": null,
-   "outputs": []
+   "source": []
   },
   {
    "cell_type": "code",
@@ -372,8 +310,8 @@
    "source": [
     "long_term_days = 90\n",
     "# Convert into seconds\n",
-    "tf_long = long_term_days*36*2400\n",
-    "sol_long = my_SIR_fitted.solve(tf_long, long_term_days)\n",
+    "tf_long = long_term_days-1\n",
+    "sol_long = my_SIR_fitted.solve(tf_long, long_term_days).fetch()\n",
     "N_S_long = sol_long[:,1]*P_Ealing\n",
     "N_I_long = sol_long[:,2]*P_Ealing\n",
     "N_R_long = sol_long[:,3]*P_Ealing"
@@ -388,7 +326,7 @@
    "outputs": [],
    "source": [
     "# Plot the number of susceptible, infected and recovered in a two months period\n",
-    "tspan_long = np.linspace(0,long_term_days,long_term_days)\n",
+    "tspan_long = np.linspace(0,tf_long,long_term_days)\n",
     "plt.figure(figsize=[15,5])\n",
     "plt.subplot(1,3,1)\n",
     "plt.plot(tspan_long,N_S_long)\n",
@@ -401,7 +339,7 @@
     "plt.title(\"Infected\")\n",
     "plt.subplot(1,3,3)\n",
     "plt.plot(tspan_long,N_R_long)\n",
-    "plt.title(\"Recovered\")\n",
+    "plt.title(\"Recovered or removed\")\n",
     "plt.xlabel('Days')\n",
     "plt.show()"
    ]
@@ -411,9 +349,7 @@
    "metadata": {},
    "source": [
     "It can be observed that the SIR model reproduces the all familiar infection bell, as well as the evolution of susceptible and recovered population. It is interesting to observe that if no measures are taken in a $R_0 = 1.47$ scenario, 65% of the Ealing population would be infected in three months."
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -422,9 +358,7 @@
     "### Sensitivity to $R_0$\n",
     "\n",
     "A known weakness of all pandemics prediction model is the sensitivity to their parameters. In the following case study, $R_0$ will be fitted to minimize the mean squared error between the model predictions and UK historical data on the Ealing borough in the time period between the 15th and the 29th of March of 2020."
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
@@ -453,7 +387,7 @@
     "    for i in alpha_list:\n",
     "        # Update parameter list\n",
     "        model.p[0] = i\n",
-    "        wsol = model.solve(tf,numpoints)\n",
+    "        wsol=model.solve(tf,numpoints).fetch()\n",
     "        S_list.append(wsol[:,1])\n",
     "        I_list.append(wsol[:,2])\n",
     "        R_list.append(wsol[:,3]) \n",
@@ -465,9 +399,7 @@
    "metadata": {},
    "source": [
     "### Generate predictions for each alpha"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
@@ -475,9 +407,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_SIR\n",
     "alpha_list = beta*np.array([1.5,1.6,1.7])\n",
-    "S_list, I_list, R_list = compare_infections(my_SIR, tf_long, int(tf_long/(24*3600)), alpha_list)#"
+    "S_list, I_list, R_list = compare_infections(my_SIR, tf_long, long_term_days, alpha_list)"
    ]
   },
   {
@@ -512,9 +443,7 @@
    "metadata": {},
    "source": [
     "We observe that a change as little as 6% in the reproduction rate, can change dramatically the dynamic of the pandemic"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -522,9 +451,7 @@
    "source": [
     "### Example 4: Fit R_0 for UK values\n",
     "[sourced from UK Arcgis](https://www.arcgis.com/apps/opsdashboard/index.html#/f94c3c90da5b4e9f9a0b19484dd4bb14)"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
@@ -535,23 +462,25 @@
     "P_UK = 67886011\n",
     "# Data up to 28th of March\n",
     "I_UK= [3269, 3983, 5018, 5683, 6650, 8077, 9529, 11658, 14543, 17089]\n",
-    "t_d = np.linspace(0,9,10)\n",
-    "t_s = t_d*3600*24\n",
+    "n_days = len(I_UK) # Final day\n",
+    "t_d = np.linspace(0,n_days-1,n_days)\n",
     "\n",
-    "S0 = (P_UK-I_UK[0])/P_UK\n",
-    "I0 = I_UK[0]/P_UK\n",
-    "w0 = [S0, I0, R0]\n",
+    "n_S0 = P_UK-I_UK[0]\n",
+    "n_I0 = I_UK[0]\n",
+    "n_R0 = 0\n",
+    "n0_UK = [n_S0, n_I0, n_R0]\n",
     "p = [alpha,beta]\n",
     "\n",
     "# Create empty model\n",
-    "SIR_UK = SIR(p, w0)\n",
+    "SIR_UK = SIR()\n",
+    "SIR_UK.set_params(p,n0_UK)\n",
     "# Train model\n",
     "SIR_UK.fit(t_d, I_UK, P_UK)\n",
     "# Build numerical solution\n",
-    "I_opt = SIR_UK.solve(t_s[-1], 10)[:,2]*P_UK\n",
+    "I_opt = SIR_UK.solve(n_days-1,n_days).fetch()[:,2]\n",
     "# lag = 6\n",
     "\n",
-    "R_opt = SIR_UK.R_0 # \n",
+    "R_opt = SIR_UK.r0 # \n",
     "\n",
     "plt.figure(figsize=[6,6])\n",
     "plt.plot(t_d,I_UK,'o')\n",
@@ -561,11 +490,25 @@
     "plt.ylabel(\"Number of people infected\")\n",
     "plt.xlabel(\"Day\")\n",
     "plt.xlim([min(t_d),max(t_d)])\n",
-    "plt.show()\n",
-    "\n",
-    "I_UK-I_opt\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "MSE = sum(np.sqrt((I_opt-I_UK)**2))/len(I_UK)        \n",
-    "print(\"Mean squared error on the predictions %.2f\" % MSE)"
+    "print(\"Mean squared error on the model in the train dataset %.2f\" % MSE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate confidence intervals\n",
+    "\n"
    ]
   },
   {
@@ -574,8 +517,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# 1 standard deviation errors on the parameter\n",
-    "MSE = sum(np.sqrt((I_opt-I_UK)**2))/len(I_opt)        "
+    "from post_regression import ci_bootstrap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "outputPrepend",
+     "outputPrepend",
+     "outputPrepend",
+     "outputPrepend",
+     "outputPrepend",
+     "outputPrepend",
+     "outputPrepend",
+     "outputPrepend",
+     "outputPrepend",
+     "outputPrepend",
+     "outputPrepend",
+     "outputPrepend"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Get the confidence interval through bootstrap\n",
+    "par_ci, par_list = ci_bootstrap(SIR_UK, t_d, I_UK, P_UK, n_iter=1000)"
    ]
   },
   {
@@ -584,22 +551,154 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Utilities that may be interesting to include in solve: predict the following days\n",
-    "pred = 3\n",
-    "I_pred = SIR_UK.solve(t_s[-1]+pred*3600*24, 10+pred)[:,2]*P_UK\n",
-    "print(\"Number of infected people predicted %.0f after %.0f days\" % (I_pred[-1], pred))\n",
+    "alpha_min = par_ci[0][0]\n",
+    "alpha_max = par_ci[0][1]\n",
+    "# Explore the confidence intervals\n",
+    "print(\"IC 95% for alpha:\", par_ci[0])\n",
+    "print(\"IC 95% for beta:\", par_ci[1])\n",
+    "print(\"IC 95% for r0:\", par_ci[2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can visualize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build numerical solution\n",
+    "I_opt = SIR_UK.solve(n_days-1, n_days).fetch()[:,2]\n",
+    "beta_0 = SIR_UK.p[1]\n",
+    "SIR_minus = SIR().set_params([alpha_min, beta_0],n0_UK)\n",
+    "SIR_plus = SIR().set_params([alpha_max, beta_0],n0_UK)\n",
+    "I_minus = SIR_minus.solve(n_days-1, n_days).fetch()[:,2]\n",
+    "I_plus = SIR_plus.solve(n_days-1, n_days).fetch()[:,2]\n",
     "\n",
-    "# 1 standard deviation errors on the parameter\n",
-    "MSE = sum(np.sqrt((I_opt-I_UK)**2))/len(I_opt)      \n",
-    "print(\"The mean squared error of the model is %.0f\" % MSE)"
+    "# lag = 6\n",
+    "\n",
+    "R_opt = SIR_UK.r0 # \n",
+    "\n",
+    "plt.figure(figsize=[6,6])\n",
+    "plt.plot(t_d,I_UK,'o')\n",
+    "plt.plot(t_d, I_opt)\n",
+    "plt.plot(t_d, I_minus)\n",
+    "plt.plot(t_d, I_plus)\n",
+    "plt.legend([\"UK Data\",\"SIR, $R_{0,opt}$ = %.2f\"%R_opt,\"IC_95-\",\"IC_95+\"])\n",
+    "plt.title(\"Fitting of the SIR model against 15 days of UK data\")\n",
+    "plt.ylabel(\"Number of people infected\")\n",
+    "plt.xlabel(\"Day\")\n",
+    "plt.xlim([min(t_d),max(t_d)])\n",
+    "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An extremely asymmetrical confidence interval for $R_0$ using simple random bootstrap is observed. This occurs most likely because of \n",
+    "neglecting the temporal structure of the exponential.\n",
+    "\n",
+    "To further investigate this phenomena, we can observe the distribution of the $R_0$ parameter on the parameter list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.hist(par_list[:,0]/par_list[:,1], bins=50, density=True, stacked=True)\n",
+    "plt.xlabel('$R_0$')\n",
+    "plt.ylabel('Frequency')\n",
+    "plt.title(\"Probability density diagram of $R_0$ bootstrapping\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is interesting to observe that the spread is assymetrical towards lower $R_0$ values. This asymmetry is expected owing to the effect of lockdowns and public policies to promote social distancing. A strong assumption of the SIR model is that the spread rate $\\alpha$ and removal rate $\\beta$ are constant, which is not the case in reality specially when strong public policies to limit the spread of a virus take place."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# par_ci, par_list = ci_bootstrap(SIR_UK, t_d, I_UK, P_UK, n_iter=1000)\n",
+    "from post_regression import ci_block_cv\n",
+    "n_lags = 1\n",
+    "MSE_avg, MSE_list, p_list = ci_block_cv(SIR_UK, t_d, I_UK, P_UK, lags=n_lags)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"The average mean squared error on the time cross validation bootstrapping is: %.3f\" % MSE_avg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can visualize the results of the block bootstrapping in terms of the variation of the reproduction rate $R_0$ and the mean squared error when a subset of the days is taken. By default, ci_block_cv starts with the data of the three days, fit the model on that data, predicts the number of infected in the next period, calculate the mean squared error between the prediction and the test dataset, and stores it into two arrays. It repeats this until it uses the data of $(n-1)$ intervals to predict the $n-th$ latest observation of infections."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r0_roll = p_list[:,0]/p_list[:,1]\n",
+    "\n",
+    "plt.figure(figsize=[10,5])\n",
+    "plt.subplot(1,2,1)\n",
+    "plt.plot(t_d[(2+n_lags):], r0_roll,'ro')\n",
+    "plt.xlabel(\"Days used in the block to fit parameters\")\n",
+    "plt.ylabel(\"Rolling $R_0$\")\n",
+    "plt.title(\"Block bootstrapping change in $R_0$\")\n",
+    "plt.subplot(1,2,2)\n",
+    "plt.plot(MSE_list,'bo')\n",
+    "plt.xlabel(\"Days used in the block to fit parameters\")\n",
+    "plt.ylabel(\"Mean squared error in number of infected\")\n",
+    "plt.title(\"Block bootstrapping change in MSE\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.7.3 64-bit ('open-sir': pipenv)",
    "language": "python",
-   "name": "python3"
+   "name": "python37364bitopensirpipenvf3ff5cf596f54fd68a10d68f17103784"
   },
   "language_info": {
    "codemirror_mode": {
@@ -611,7 +710,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3-final"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/model.py
+++ b/model.py
@@ -1,12 +1,13 @@
 """ Model implementation """
-import numpy as np # Numerical computing
-from scipy.integrate import odeint # ODE system numerical integrator
+import numpy as np  # Numerical computing
+from scipy.integrate import odeint  # ODE system numerical integrator
 from scipy.optimize import curve_fit
 
 ABSERR = 1.0e-8
 RELERR = 1.0e-6
 DAYS = 7
 NUMPOINTS = DAYS
+
 
 def call_solver(func, p, w0, t):
     """
@@ -39,11 +40,11 @@ def sir(w, t, p):
     f: right hand side of the system of differential equation
     """
     # unpack state variable
-    s, i, r = w   # pylint: disable=W0612
+    s, i, r = w  # pylint: disable=W0612
     # unpack parameter
     alpha, beta = p
-    ds_dt = -alpha*s*i
-    di_dt = alpha*s*i - beta*i
+    ds_dt = -alpha * s * i
+    di_dt = alpha * s * i - beta * i
     dr_dt = beta * i
 
     return [ds_dt, di_dt, dr_dt]
@@ -68,20 +69,20 @@ def sirx(w, t, p):
     right hand side of the system of differential equation
     """
     # unpack state variable
-    s, i, r, x = w   # pylint: disable=W0612
+    s, i, r, x = w  # pylint: disable=W0612
     # unpack parameter
     alpha, beta, kappa_0, kappa = p
-    ds_dt = -alpha*s*i - kappa_0*s
-    di_dt = alpha*s*i - beta*i - kappa_0*i - kappa*i
-    dr_dt = kappa_0*s + beta * i
+    ds_dt = -alpha * s * i - kappa_0 * s
+    di_dt = alpha * s * i - beta * i - kappa_0 * i - kappa * i
+    dr_dt = kappa_0 * s + beta * i
     dx_dt = (kappa_0 + kappa) * i
-
 
     return [ds_dt, di_dt, dr_dt, dx_dt]
 
 
 class Model:
     """ Base model definition """
+
     CSV_ROW = []
     NUM_PARAMS = 4
     NUM_IC = 4
@@ -107,11 +108,13 @@ class Model:
         num_ic = self.__class__.NUM_IC
 
         if len(p) != num_params or len(initial_conds) != num_ic:
-            raise Exception("Invalid number of parameters \
-                             or initial conditions")
+            raise Exception(
+                "Invalid number of parameters \
+                             or initial conditions"
+            )
         self.p = p
         self.pop = np.sum(initial_conds)
-        self.w0 = initial_conds/self.pop
+        self.w0 = initial_conds / self.pop
         return self
 
     def export(self, f, delimiter=","):
@@ -125,8 +128,7 @@ class Model:
         if self.sol is None:
             raise Exception("Missing call to solve()")
 
-        np.savetxt(f, self.sol, header=",".join(self.__class__.CSV_ROW),
-                   delimiter=",")
+        np.savetxt(f, self.sol, header=",".join(self.__class__.CSV_ROW), delimiter=",")
 
     def fetch(self):
         """ Fetch the data from the model.
@@ -144,9 +146,7 @@ class Model:
         Reference to self
         """
         tspan = np.linspace(0, tf_days, numpoints)
-
-        sol = call_solver(self.__class__.FUNC, self.p, self.w0,
-                          tspan)
+        sol = call_solver(self.__class__.FUNC, self.p, self.w0, tspan)
         # Multiply by the population
         sol[:, 1:] *= self.pop
 
@@ -157,7 +157,7 @@ class Model:
     def r0(self):
         """ Returns reproduction number
         r0 = alpha/beta"""
-        return self.p[0]/self.p[1]
+        return self.p[0] / self.p[1]
 
     def fit(self, t_obs, n_i_obs, population, inplace=False):
         """ Use the Levenberg-Marquardt algorithm to fit
@@ -204,22 +204,24 @@ class SIR(Model):
           n_I0: Toral number of infected
           n_R0: Total number of recovered
           Note n_S0 + n_I0 + n_R0 = Population
-          
+
           Internally, the model initial conditions are the ratios
           S0 = n_S0/Population
           I0 = n_I0/Population
           R0 = n_R0/Population
           which is consistent with the mathematical description
           of the SIR model.
-          
+
         output:
         reference to self
         """
         self._set_params(p, initial_conds)
         return self
 
+
 class SIRX(Model):
     """ SIRX model definition """
+
     CSV_ROW = ["Days", "S", "I", "R", "X"]
     NUM_PARAMS = 4
     NUM_IC = 4
@@ -236,7 +238,7 @@ class SIRX(Model):
           n_R0: Total number of recovered
           n_X0: Total number of quarantined
           Note: n_S0 + n_I0 + n_R0 + n_X0 = Population
-        
+
         Internally, the model initial conditions are the ratios
           S0 = n_S0/Population
           I0 = n_I0/Population
@@ -244,7 +246,7 @@ class SIRX(Model):
           X0 = n_X0/Population
           which is consistent with the mathematical description
           of the SIR model.
-          
+
         output:
         reference to self
         """

--- a/post_regression.py
+++ b/post_regression.py
@@ -1,0 +1,188 @@
+"""Post regression utilities"""
+import numpy as np
+from sklearn.utils import resample
+
+
+def ci_bootstrap(
+    model, t_obs, n_I_obs, population, alpha=0.95, n_iter=1000, r0_ci=True
+):
+    """
+    Calculates the confidence interval of the parameters
+    using the random sample bootstrap method.
+
+    Parameters
+    ----------
+    model : open-sir Model instance
+        A Model instance, such as SIR or SIRX
+
+    t_obs : list or np.array
+        List of days where the number of infected
+        where measured
+
+    n_I_obs: list or np.array
+        List with measurements of number of infected people
+        in a population. Must be consistent with t_obs.
+
+    population : integer
+        Population size
+
+    alpha : numerical scalar, optional
+        Percentile of the confidence interval required
+
+    n_iter : integer, optional
+        Number of random samples that will be taken to fit the model
+        and perform the bootstrapping. Use n_iter >= 1000.
+
+    Returns
+    -------
+    ci : numpy.array
+        Numpy array with a list of lists that contain the lower and upper
+        confidence intervals of each parameter.
+    p_bt : numpy.array
+        list of the parameters sampled on the bootstrapping. The most
+        common use of this list is to plot histograms to visualize and
+        try to infer the probability density function of the parameters.
+
+    Notes:
+    -----------
+    This traditional random sampling bootstrap is not a good way to bootstrap
+    time-series data , baceuse the data because X(t+1) is
+    correlated with X(t). In any case, it provides a reference
+    case and it will can be an useful method for other types
+    of models. When using this function, always compare the prediction error
+    with the interval provided by the function ci_block_cv.
+    """
+
+    p0 = model.p
+    w0 = model.w0
+
+    p_bt = []
+    if r0_ci:
+        r0_bt = []
+
+    # Perform bootstraping
+    for i in range(0, n_iter):
+        t_r, I_r = resample(t_obs, n_I_obs)
+        I_r = np.array(I_r)
+        # Sort and redefine arrays
+        idx = np.argsort(t_r)
+        t_rs = t_r[idx]
+        I_rs = I_r[idx]
+        # Fit the model to the sampled data
+        # Update model initial conditions
+        nI0_rs = I_rs[0]
+        nS0_rs = population - nI0_rs
+        nR0_rs = 0  # We will still assume that we don't have observations of recovered
+        w0_rs = [nS0_rs, nI0_rs, nR0_rs]
+        model.set_params(model.p, w0_rs)
+        model.fit(t_rs, I_rs, population)
+        p_bt.append(model.p)
+        if r0_ci:
+            r0_bt.append(model.r0)
+    # Calculate percentiles value
+    p_low = ((1 - alpha) / 2) * 100
+    p_up = (alpha + (1 - alpha) / 2) * 100
+    # From the resulting distribution, extract the
+    # percentile value of the parameters
+
+    p_bt = np.array(p_bt)
+
+    # Construct confidence intervals
+    ci = []
+    for i in range(0, len(model.p)):
+        ci_low = np.percentile(p_bt[:, i], p_low)
+        ci_up = np.percentile(p_bt[:, i], p_up)
+        ci.append([ci_low, ci_up])
+
+    if r0_ci:
+        ci.append([np.percentile(r0_bt, p_low), np.percentile(r0_bt, p_up)])
+
+    ci = np.array(ci)
+    # Reconstruct model original parameters
+    model.p = p0
+    model.w0 = w0
+
+    return ci, p_bt
+
+
+def ci_block_cv(model, t_obs, n_I_obs, population, lags=1, min_sample=3):
+    """ Calculates the confidence interval of the model parameters
+    using a block cross validation appropriate for time series
+    and differential systems when the value of the states in the
+    time (t+1) is not independent from the value of the states in the
+    time t.
+
+    Parameters:
+    -----------
+
+    model: a open-sir model instance
+        The model needs to be initialized with the parameters and
+        initial conditions
+
+    t_obs : list or np.array
+        List of days where the number of infected
+        where measured
+
+    n_I_obs: list or np.parray
+        List with measurements of number of infected people
+        in a population. Must be consistent with t_obs.
+
+    population : integer
+        population size
+
+    lags : integer, optional
+        Defines the number of days that will be forecasted to calculate
+        the mean squared error. For example, for the prediction Xp(t) and the
+        real value X(t), the mean squared error will be calculated as
+        mse = 1/n_boots |Xp(t+lags)-X(t+lags)|. This provides an estimate of the
+        mean deviation of the predictions after "lags" days.
+        alpha: percentile of the CI required
+
+    min_sample : integer, optional
+        Number of days that will be used in the train set
+        to make the first prediction.
+
+    Returns:
+    --------
+    mse_avg : float
+        Simple average of the mean squared error between the model
+        prediction for "lags" days and the real observed value.
+
+    mse_list : numpy array
+        List of the mean squared errors using (i) points to
+        predict the X(i+lags) value, with i an iterator that
+        goes from n_samples+1 to the end of t_obs index.
+
+    p_list : numpy.array
+        List of the parameters sampled on the bootstrapping as a
+        function of time. A common use of this list is to plot the
+        mean squared error against time, to identify time periods
+        where the model produces the best and worst fit to the data.
+    """
+
+    p0 = model.p
+    w0 = model.w0
+
+    # Consider at least the three first datapoints
+    p_list = []
+    mse_list = []  # List of mean squared errors of the prediction for the time t+1
+    for i in range(min_sample - 1, len(n_I_obs) - lags):
+        # Fit model to a subset of the time-series data
+        model.fit(t_obs[0:i], n_I_obs[0:i], population)
+        # Store the rolling parameters
+        p_list.append(model.p)
+        # Predict for the i+1 period
+        model.solve(t_obs[i + lags], numpoints=int(t_obs[i + lags]) + 1)
+        pred = model.fetch()[:, 2]
+        # Calculate mean squared errors
+        mse = np.sqrt((pred[i - 1 + lags] - n_I_obs[i - 1 + lags]) ** 2)
+        mse_list.append(mse)
+
+    p_list = np.array(p_list)
+    mse_list = np.array(mse_list)
+    mse_avg = np.mean(mse_list)
+
+    model.p = p0
+    model.w = w0
+
+    return mse_avg, mse_list, p_list


### PR DESCRIPTION
This pull request contains the same last commit of the confidence_interval branch, as I messed up dramatically the previous branch.

This PR contains:

1. Some style changes to model.py
2. An updated version of the **model.fit()** function, in order to be compatible with the changes included by @jia200x regarding storing the solution in the model object.
3. Two routines to calculate confidence intervals, contained in **post_regression.py**
3.1 sklearn is included in the pipfile as the bootstrapping method of confidence intervals require the sklearn resample functions
4. The Jupyter notebook was updated to reflect all previous changes

Following up a discussion with @jia200x, the confidence intervals routines will be part of the model class in the future. However, this will be part of a separate PR and won't affect significantly it's functionality.

I am thankful to @jia200x who taught me about git basics (and some advanced) techniques. I recommend everyone new to git and github to take the online software carpentry course:

https://swcarpentry.github.io/git-novice/

As it provides a good basis and will prevent wasting time on mistakes. Although enervating for the novice, Git is important, powerful and will make this software of high quality. And we need high quality because we are predicting results that can save human lives.