### PR TITLE
docs: add sphinx documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,15 @@ jobs:
           name: Run tests
           command: pipenv run test
 
+  docs:
+    description: Build docs
+    executor: py-executor
+    steps:
+      - bootstrap
+      - run:
+          name: Build docs
+          command: pipenv run doc
+
   build:
     description: Build Docker image
     executor: docker/machine
@@ -74,10 +83,14 @@ workflows:
       - test:
           requires:
             - bootstrap
+      - docs:
+          requires:
+            - bootstrap
       - build:
           requires:
             - lint
             - test
+            - docs
           filters:
             branches:
               ignore:
@@ -86,6 +99,7 @@ workflows:
           requires:
             - lint
             - test
+            - docs
           filters:
             branches:
               only: master

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+_build/
 develop-eggs/
 dist/
 downloads/

--- a/Pipfile
+++ b/Pipfile
@@ -27,4 +27,4 @@ allow_prereleases = true
 start = "python open-sir.py"
 lint = "pylint **/*.py"
 test = "pytest"
-doc = "make html"
+doc = "sphinx-build -M html . _build"

--- a/Pipfile
+++ b/Pipfile
@@ -27,3 +27,4 @@ allow_prereleases = true
 start = "python open-sir.py"
 lint = "pylint **/*.py"
 test = "pytest"
+doc = "make html"

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,8 @@ matplotlib = "*"
 scipy = "*"
 jupyter = "*"
 sklearn = "*"
+sphinx = "*"
+sphinx-rtd-theme = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6991db8b4e72c3238e04cc4a6e0470a795a90a242509cdce85b4526cd9c582f1"
+            "sha256": "3ff7b79f893f161ed540343c860331284b69e60561dbfa3b783fe60df3e6a94a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,12 +16,33 @@
         ]
     },
     "default": {
+        "alabaster": {
+            "hashes": [
+                "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359",
+                "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"
+            ],
+            "version": "==0.7.12"
+        },
+        "async-generator": {
+            "hashes": [
+                "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b",
+                "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144"
+            ],
+            "version": "==1.10"
+        },
         "attrs": {
             "hashes": [
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
                 "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
             "version": "==19.3.0"
+        },
+        "babel": {
+            "hashes": [
+                "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
+                "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
+            ],
+            "version": "==2.8.0"
         },
         "backcall": {
             "hashes": [
@@ -36,6 +57,20 @@
                 "sha256:e78e426105ac07026ba098f04de8abe9b6e3e98b5befbf89b51a5ef0a4292b03"
             ],
             "version": "==3.1.4"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+            ],
+            "version": "==2019.11.28"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
         },
         "cycler": {
             "hashes": [
@@ -58,12 +93,33 @@
             ],
             "version": "==0.6.0"
         },
+        "docutils": {
+            "hashes": [
+                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
+                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
+            ],
+            "version": "==0.16"
+        },
         "entrypoints": {
             "hashes": [
                 "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
                 "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
             ],
             "version": "==0.3"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+            ],
+            "version": "==2.9"
+        },
+        "imagesize": {
+            "hashes": [
+                "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
+                "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
+            ],
+            "version": "==1.2.0"
         },
         "importlib-metadata": {
             "hashes": [
@@ -252,12 +308,19 @@
             ],
             "version": "==0.8.4"
         },
+        "nbclient": {
+            "hashes": [
+                "sha256:193731fd5039061dbd7d6d3f765a2fa59d23012594d68b1798deea9c3eae4a01",
+                "sha256:44dde0356def1d9345908c8f58dc604a434f2fe61c49ac13fac6e2da2ae429de"
+            ],
+            "version": "==0.2.0"
+        },
         "nbconvert": {
             "hashes": [
-                "sha256:944a5fbe6c4609d74e7f331bfa957c8eff2d53904f7c40f053a44bfb4164b718",
-                "sha256:c86da6adc412df9ad2726fe438589e4495c7835792d6d84f888178682f5d5bcf"
+                "sha256:4b2eff78c254a85d1668af70fca1cab4cecb077324ca72a1ac8959af08e78e3d",
+                "sha256:b327e1e75673fa4e76659396a0a012cb144bf3adc7aba3b55756de9497a2215e"
             ],
-            "version": "==6.0.0a0"
+            "version": "==6.0.0a1"
         },
         "nbformat": {
             "hashes": [
@@ -265,6 +328,13 @@
                 "sha256:f0c47cf93c505cb943e2f131ef32b8ae869292b5f9f279db2bafb35867923f69"
             ],
             "version": "==5.0.5"
+        },
+        "nest-asyncio": {
+            "hashes": [
+                "sha256:14e194b72144052a82173ca9109bd07c57813a320f42c7acfad1e4d329988350",
+                "sha256:b4cdd08655e2848098d204a26590cbfa39fcbc4ad1811c568678ffc8a0c8e279"
+            ],
+            "version": "==1.3.2"
         },
         "notebook": {
             "hashes": [
@@ -299,6 +369,13 @@
             ],
             "index": "pypi",
             "version": "==1.18.2"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
+                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+            ],
+            "version": "==20.3"
         },
         "pandocfilters": {
             "hashes": [
@@ -376,6 +453,13 @@
             ],
             "version": "==2.8.1"
         },
+        "pytz": {
+            "hashes": [
+                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
+                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+            ],
+            "version": "==2019.3"
+        },
         "pyzmq": {
             "hashes": [
                 "sha256:0bbc1728fe4314b4ca46249c33873a390559edac7c217ec7001b5e0c34a8fb7f",
@@ -422,6 +506,13 @@
                 "sha256:fa0b8363b363e89b2a6f49eddc162a04c0699ae95e109a6be3bb145a913190ea"
             ],
             "version": "==1.9.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+            ],
+            "version": "==2.23.0"
         },
         "scikit-learn": {
             "hashes": [
@@ -497,6 +588,71 @@
             "index": "pypi",
             "version": "==0.0"
         },
+        "snowballstemmer": {
+            "hashes": [
+                "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0",
+                "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
+            ],
+            "version": "==2.0.0"
+        },
+        "sphinx": {
+            "hashes": [
+                "sha256:588ab849305802b0d68e550c9fb7de25555e8b0ce82ceaa5c2826aa518e97a75",
+                "sha256:5f8c74f548865d7ea0cd3c496da98d41ec822f229445281017630d290b8c0851"
+            ],
+            "index": "pypi",
+            "version": "==3.0.0b1"
+        },
+        "sphinx-rtd-theme": {
+            "hashes": [
+                "sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4",
+                "sha256:728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a"
+            ],
+            "index": "pypi",
+            "version": "==0.4.3"
+        },
+        "sphinxcontrib-applehelp": {
+            "hashes": [
+                "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
+                "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"
+            ],
+            "version": "==1.0.2"
+        },
+        "sphinxcontrib-devhelp": {
+            "hashes": [
+                "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
+                "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
+            ],
+            "version": "==1.0.2"
+        },
+        "sphinxcontrib-htmlhelp": {
+            "hashes": [
+                "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f",
+                "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"
+            ],
+            "version": "==1.0.3"
+        },
+        "sphinxcontrib-jsmath": {
+            "hashes": [
+                "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
+                "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
+            ],
+            "version": "==1.0.1"
+        },
+        "sphinxcontrib-qthelp": {
+            "hashes": [
+                "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72",
+                "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"
+            ],
+            "version": "==1.0.3"
+        },
+        "sphinxcontrib-serializinghtml": {
+            "hashes": [
+                "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc",
+                "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"
+            ],
+            "version": "==1.1.4"
+        },
         "terminado": {
             "hashes": [
                 "sha256:4804a774f802306a7d9af7322193c5390f1da0abb429e082a10ef1d46e6fb2c2",
@@ -531,6 +687,13 @@
                 "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"
             ],
             "version": "==4.3.3"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+            ],
+            "version": "==1.25.8"
         },
         "wcwidth": {
             "hashes": [
@@ -706,29 +869,29 @@
         },
         "regex": {
             "hashes": [
-                "sha256:01b2d70cbaed11f72e57c1cfbaca71b02e3b98f739ce33f5f26f71859ad90431",
-                "sha256:046e83a8b160aff37e7034139a336b660b01dbfe58706f9d73f5cdc6b3460242",
-                "sha256:113309e819634f499d0006f6200700c8209a2a8bf6bd1bdc863a4d9d6776a5d1",
-                "sha256:200539b5124bc4721247a823a47d116a7a23e62cc6695744e3eb5454a8888e6d",
-                "sha256:25f4ce26b68425b80a233ce7b6218743c71cf7297dbe02feab1d711a2bf90045",
-                "sha256:269f0c5ff23639316b29f31df199f401e4cb87529eafff0c76828071635d417b",
-                "sha256:5de40649d4f88a15c9489ed37f88f053c15400257eeb18425ac7ed0a4e119400",
-                "sha256:7f78f963e62a61e294adb6ff5db901b629ef78cb2a1cfce3cf4eeba80c1c67aa",
-                "sha256:82469a0c1330a4beb3d42568f82dffa32226ced006e0b063719468dcd40ffdf0",
-                "sha256:8c2b7fa4d72781577ac45ab658da44c7518e6d96e2a50d04ecb0fd8f28b21d69",
-                "sha256:974535648f31c2b712a6b2595969f8ab370834080e00ab24e5dbb9d19b8bfb74",
-                "sha256:99272d6b6a68c7ae4391908fc15f6b8c9a6c345a46b632d7fdb7ef6c883a2bbb",
-                "sha256:9b64a4cc825ec4df262050c17e18f60252cdd94742b4ba1286bcfe481f1c0f26",
-                "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5",
-                "sha256:9ff16d994309b26a1cdf666a6309c1ef51ad4f72f99d3392bcd7b7139577a1f2",
-                "sha256:b33ebcd0222c1d77e61dbcd04a9fd139359bded86803063d3d2d197b796c63ce",
-                "sha256:bba52d72e16a554d1894a0cc74041da50eea99a8483e591a9edf1025a66843ab",
-                "sha256:bed7986547ce54d230fd8721aba6fd19459cdc6d315497b98686d0416efaff4e",
-                "sha256:c7f58a0e0e13fb44623b65b01052dae8e820ed9b8b654bb6296bc9c41f571b70",
-                "sha256:d58a4fa7910102500722defbde6e2816b0372a4fcc85c7e239323767c74f5cbc",
-                "sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0"
+                "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b",
+                "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8",
+                "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3",
+                "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e",
+                "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683",
+                "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1",
+                "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142",
+                "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3",
+                "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468",
+                "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e",
+                "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3",
+                "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a",
+                "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f",
+                "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6",
+                "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156",
+                "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b",
+                "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db",
+                "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd",
+                "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a",
+                "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948",
+                "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"
             ],
-            "version": "==2020.2.20"
+            "version": "==2020.4.4"
         },
         "six": {
             "hashes": [

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,54 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Open-SIR'
+copyright = '2020, José I. Alamos, Felipe Huerta, Sebastián Salata'
+author = 'José I. Alamos, Felipe Huerta, Sebastián Salata'
+
+# The full version, including alpha/beta/rc tags
+release = '1.0.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/index.rst
+++ b/index.rst
@@ -1,0 +1,26 @@
+.. Open-SIR documentation master file, created by
+   sphinx-quickstart on Sun Apr  5 12:09:27 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Open-SIR's documentation!
+====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+.. autoclass:: models.SIR
+   :members:
+   :inherited-members:
+
+.. autoclass:: models.SIRX
+   :members:
+   :inherited-members:
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/models/model.py
+++ b/models/model.py
@@ -44,11 +44,14 @@ class Model:
 
     def _set_params(self, p, initial_conds):
         """ Set model parameters.
-        input:
-        p: parameters of the model. The parameters units are 1/day.
-        initial_conds: Initial conditions, in total number of individuals.
-        For instance, S0 = n_S0/population, where n_S0 is the number of subjects
-        who are susceptible to the disease.
+        Args:
+            p (list): parameters of the model. The parameters units are 1/day.
+            initial_conds (list): Initial conditions, in total number of individuals.
+            For instance, S0 = n_S0/population, where n_S0 is the number of subjects
+            who are susceptible to the disease.
+
+        Returns:
+            Model: Reference to self
         """
 
         num_params = self.__class__.NUM_PARAMS
@@ -65,12 +68,14 @@ class Model:
         return self
 
     def export(self, f, delimiter=","):
-        """ Export the output of the model in CSV format
-        Calling this before solve() raises an exception.
+        """ Export the output of the model in CSV format.
 
-        input:
-        f: file name or descriptor
-        delimiter: delimiter of the CSV file
+        Note:
+            Calling this before solve() raises an exception.
+
+        Args:
+            f: file name or descriptor
+            delimiter (str): delimiter of the CSV file
         """
         if self.sol is None:
             raise Exception("Missing call to solve()")
@@ -79,18 +84,21 @@ class Model:
 
     def fetch(self):
         """ Fetch the data from the model.
-        The first row is the time in days
+
+        Returns:
+            np.array: An array with the data. The first column is the time.
         """
         return self.sol
 
     def solve(self, tf_days=DAYS, numpoints=NUMPOINTS):
         """ Solve using children class model.
-        input:
-        tf_days: number of days to simulate
-        numpoints: number of points for the simulation.
 
-        output:
-        Reference to self
+        Args:
+            tf_days (int): number of days to simulate
+            numpoints (int): number of points for the simulation.
+
+        Returns:
+            Model: Reference to self
         """
         tspan = np.linspace(0, tf_days, numpoints)
         sol = call_solver(self._model, self.p, self.w0, tspan)
@@ -103,19 +111,24 @@ class Model:
     @property
     def r0(self):
         """ Returns reproduction number
-        r0 = alpha/beta"""
+
+        Returns:
+            float: r0 (alpha/beta)
+        """
         return self.p[0] / self.p[1]
 
     def fit(self, t_obs, n_i_obs, population, fit_index=None):
         """ Use the Levenberg-Marquardt algorithm to fit
         the parameter alpha, as beta is assumed constant
 
-        inputs:
-        t_obs: Vector of days corresponding to the observations of number of infected people
-        n_i_obs: Vector of number of infected people
-        population: Size of the objective population
+        Args:
+            t_obs (np.array): Vector of days corresponding to the observations
+            of number of infected people
+            n_i_obs (np.array): Vector of number of infected people
+            population: Size of the objective population
 
-        Return
+        Returns:
+            Model: Reference to self
         """
 
         # if no par_index is provided, fit only the first parameter

--- a/models/sir.py
+++ b/models/sir.py
@@ -37,24 +37,29 @@ class SIR(Model):
 
     def set_params(self, p, initial_conds):
         """ Set model parameters.
-        input:
-        p: parameters of the model [alpha, beta]. All these
-           values should be in 1/day units.
-        initial_conds: Initial conditions (n_S0, n_I0, n_R0), where:
-          n_S0: Total number of susceptible to the infection
-          n_I0: Toral number of infected
-          n_R0: Total number of recovered
-          Note n_S0 + n_I0 + n_R0 = Population
 
-          Internally, the model initial conditions are the ratios
-          S0 = n_S0/Population
-          I0 = n_I0/Population
-          R0 = n_R0/Population
-          which is consistent with the mathematical description
-          of the SIR model.
+        Args:
+            p (list): parameters of the model [alpha, beta]. All these
+                 values should be in 1/day units.
+            initial_conds (list): Initial conditions (n_S0, n_I0, n_R0), where:
 
-        output:
-        reference to self
+                - n_S0: Total number of susceptible to the infection
+                - n_I0: Toral number of infected
+                - n_R0: Total number of recovered
+
+                Note n_S0 + n_I0 + n_R0 = Population
+
+                Internally, the model initial conditions are the ratios
+
+                - S0 = n_S0/Population
+                - I0 = n_I0/Population
+                - R0 = n_R0/Population
+
+                which is consistent with the mathematical description
+                of the SIR model.
+
+        Returns:
+            SIR: reference to self
         """
         self._set_params(p, initial_conds)
         return self

--- a/models/sirx.py
+++ b/models/sirx.py
@@ -42,26 +42,31 @@ class SIRX(Model):
 
     def set_params(self, p, initial_conds):
         """ Set model parameters.
-        input:
-        p: parameters of the model [alpha, beta, kappa_0, kappa]. All these
-           values should be in 1/day units.
-        initial_conds: Initial conditions (S0, I0, R0, X0), where:
-          n_S0: Total number of susceptible to the infection
-          n_I0: Total number of infected
-          n_R0: Total number of recovered
-          n_X0: Total number of quarantined
-          Note: n_S0 + n_I0 + n_R0 + n_X0 = Population
 
-        Internally, the model initial conditions are the ratios
-          S0 = n_S0/Population
-          I0 = n_I0/Population
-          R0 = n_R0/Population
-          X0 = n_X0/Population
-          which is consistent with the mathematical description
-          of the SIR model.
+        Args:
+            p (list): parameters of the model [alpha, beta, kappa_0, kappa]. All these
+                 values should be in 1/day units.
+            initial_conds (list): Initial conditions (n_S0, n_I0, n_R0, n_X0), where:
 
-        output:
-        reference to self
+                - n_S0: Total number of susceptible to the infection
+                - n_I0: Total number of infected
+                - n_R0: Total number of recovered
+                - n_X0: Total number of quarantined
+
+                Note: n_S0 + n_I0 + n_R0 + n_X0 = Population
+
+                Internally, the model initial conditions are the ratios
+
+                - S0 = n_S0/Population
+                - I0 = n_I0/Population
+                - R0 = n_R0/Population
+                - X0 = n_X0/Population
+
+                which is consistent with the mathematical description
+                of the SIR model.
+
+        Returns:
+            SIRX: Reference to self
         """
         self._set_params(p, initial_conds)
         return self


### PR DESCRIPTION
This PR adds initial support for Sphinx documentation.

I suggest to read [this](https://brendanhasz.github.io/2019/01/05/sphinx.html) to have a better understanding of the usage The root file Sphinx file is the `index.rst`, from there we can include other files and module documentation.

To build the documentation:
- `pipenv run doc`

This command will call Sphinx's `make html` command to build HTML documentation. Other documentation formats are also available (man pages, latex, JSON, XML, etc).

The documentation is placed under `_build/html/index.html`

This PR also adds CircleCI build tests for the documentation, so we ensure the documentation is always consistent.

We need to slowly migrate all functions to their Sphinx format.