### PR TITLE
pipenv: Set CLI as 'start' script

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,6 @@ python_version = "3.7"
 allow_prereleases = true
 
 [scripts]
-start = "python app.py"
+start = "python open-sir.py"
 lint = "pylint **/*.py"
 test = "pytest"

--- a/app.py
+++ b/app.py
@@ -1,3 +1,0 @@
-"""Hello world"""
-
-print("Hello world!")


### PR DESCRIPTION
## Contribution
This removes the stub `app.py` script and uses the CLI application as entry-point for the pipenv script.

## Testing
- Run `pipenv run start` and the CLI should be run.