### PR TITLE
ci: remove env variables check when building Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,6 @@ jobs:
     executor: docker/machine
     steps:
       - checkout
-      - docker/check
       - docker/build:
           image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
 


### PR DESCRIPTION
This PR removes the env variables check in the CircleCI `build` job. These env variables were not being exposed for forked PRs (security reasons), and were not really needed for this step.