### PR TITLE
refactor(model): use property to extract model

### DIFF
--- a/models/model.py
+++ b/models/model.py
@@ -30,7 +30,6 @@ class Model:
     CSV_ROW = []
     NUM_PARAMS = 4
     NUM_IC = 4
-    FUNC = None
 
     def __init__(self):
         self.sol = None
@@ -38,6 +37,10 @@ class Model:
         self.pop = None
         self.w0 = None
         self.pcov = None
+
+    @property
+    def _model(self):
+        raise Exception()
 
     def _set_params(self, p, initial_conds):
         """ Set model parameters.
@@ -90,7 +93,7 @@ class Model:
         Reference to self
         """
         tspan = np.linspace(0, tf_days, numpoints)
-        sol = call_solver(self.__class__.FUNC, self.p, self.w0, tspan)
+        sol = call_solver(self._model, self.p, self.w0, tspan)
         # Multiply by the population
         sol[:, 1:] *= self.pop
 
@@ -129,7 +132,7 @@ class Model:
             params = np.array(self.p)
             params[fit_index] = par_fit
             self.p = params
-            i_mod = call_solver(self.__class__.FUNC, self.p, self.w0, t)
+            i_mod = call_solver(self._model, self.p, self.w0, t)
             return i_mod[:, 2] * pop
 
         # Fit parameters

--- a/models/sir.py
+++ b/models/sir.py
@@ -34,7 +34,6 @@ class SIR(Model):
     CSV_ROW = ["Days", "S", "I", "R"]
     NUM_PARAMS = 2
     NUM_IC = 3
-    FUNC = sir
 
     def set_params(self, p, initial_conds):
         """ Set model parameters.
@@ -59,3 +58,7 @@ class SIR(Model):
         """
         self._set_params(p, initial_conds)
         return self
+
+    @property
+    def _model(self):
+        return sir

--- a/models/sirx.py
+++ b/models/sirx.py
@@ -39,7 +39,6 @@ class SIRX(Model):
     CSV_ROW = ["Days", "S", "I", "R", "X"]
     NUM_PARAMS = 4
     NUM_IC = 4
-    FUNC = sirx
 
     def set_params(self, p, initial_conds):
         """ Set model parameters.
@@ -66,3 +65,7 @@ class SIRX(Model):
         """
         self._set_params(p, initial_conds)
         return self
+
+    @property
+    def _model(self):
+        return sirx


### PR DESCRIPTION
This PR removes the `FUNC` variable to store the specific model, and adds a private "_model" member to extract that function.

It's required in order to merge #20 