### PR TITLE
cli: improve CLI user experience

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ jupyter = "*"
 sklearn = "*"
 sphinx = "*"
 sphinx-rtd-theme = "*"
+toml = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3ff7b79f893f161ed540343c860331284b69e60561dbfa3b783fe60df3e6a94a"
+            "sha256": "e47c647d834c20b92e909756ffaac4f131c6473c383a3ce5e3ca71eb12310dec"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -60,10 +60,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
-                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
+                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
             ],
-            "version": "==2019.11.28"
+            "version": "==2020.4.5.1"
         },
         "chardet": {
             "hashes": [
@@ -435,10 +435,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
-                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
+                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
             ],
-            "version": "==2.4.6"
+            "version": "==3.0.0a1"
         },
         "pyrsistent": {
             "hashes": [
@@ -597,11 +597,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:588ab849305802b0d68e550c9fb7de25555e8b0ce82ceaa5c2826aa518e97a75",
-                "sha256:5f8c74f548865d7ea0cd3c496da98d41ec822f229445281017630d290b8c0851"
+                "sha256:6a099e6faffdc3ceba99ca8c2d09982d43022245e409249375edf111caf79ed3",
+                "sha256:b63a0c879c4ff9a4dffcb05217fa55672ce07abdeb81e33c73303a563f8d8901"
             ],
             "index": "pypi",
-            "version": "==3.0.0b1"
+            "version": "==3.0.0"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -666,6 +666,14 @@
                 "sha256:bfcf9411ef4bf3db7579063e0546938b1edda3d69f4e1fb8756991f5951f85d4"
             ],
             "version": "==0.4.4"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "index": "pypi",
+            "version": "==0.10.0"
         },
         "tornado": {
             "hashes": [
@@ -825,10 +833,10 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:163b0632d4e31cef212976cf57b43d9fd6b0bac6e67c26015d611a647d5e7424",
-                "sha256:562aa70af2e0d434367d9790ad37aed893de47f1693e4201fd1d3dca15d19b96"
+                "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0",
+                "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"
             ],
-            "version": "==0.7.0"
+            "version": "==0.8.0"
         },
         "pluggy": {
             "hashes": [
@@ -854,10 +862,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
-                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
+                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
             ],
-            "version": "==2.4.6"
+            "version": "==3.0.0a1"
         },
         "pytest": {
             "hashes": [
@@ -905,6 +913,7 @@
                 "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
+            "index": "pypi",
             "version": "==0.10.0"
         },
         "typed-ast": {

--- a/README.md
+++ b/README.md
@@ -41,13 +41,61 @@ case that no lockdown would be taking place.
 
 ### Command line interface
 
-Check that the installation was successful by calling the CLI:
+It's possible to run the model using the CLI:
 
 ```
-opensir-cli -p '[0.95,0.38]' -i '[341555,445,0]' -t 6 > data.csv
+usage: opensir-cli [-h] [-m {sir,sirx}] [-t TIME] [-f FILE] [-s] [-d DELIMITER]
+
+Run SIR or SIR-X model given a set of initial conditions and model parameters.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -m {sir,sirx}, --model {sir,sirx}
+  -t TIME, --time TIME  Number of days for the simulation
+  -f FILE, --file FILE  Name of the input file. If missing, the input file is read from STDIN
+  -s, --suppress_header
+                        Suppress CSV header
+  -d DELIMITER, --delimiter DELIMITER
+                        CSV delimiter
 ```
 
-The output of opensir-cli is a .csv file with the predictions.
+The input file is a TOML file with the following format
+
+```
+[initial_conds]
+<cond> = value
+
+[parameters]
+<paran> = value
+```
+
+For instance, the following data is valid for running the SIR model with
+alpha=0.95, beta=0.38 and initial conditions S0=341555, I0=445 and R0=0
+
+```
+[initial_conds]
+S0 = 341555
+I0 = 445
+R0 = 0
+
+[parameters]
+alpha = 0.95
+beta = 0.38
+```
+
+Then, it's possible to run the model with T=6 days:
+
+```
+opensir-cli --model sir --time 6 --file input_file.txt
+```
+
+Or reading the input file from STDIN:
+
+```
+cat input_file | opensir-cli --model sir --time 6
+```
+
+The output of opensir-cli is a .csv file with the output of the model.
 
 *Note: On Windows, the CLI must be run from Powershell or any bash shell such as [Git BASH](https://gitforwindows.org/)*
 
@@ -97,7 +145,7 @@ pipenv shell
 ```
 You can run the following command to check that the installation succeeded.
 ```
-pipenv run start -p '[0.95,0.38]' -i '[341555,445,0]' -t 6
+pipenv run start -i input_file.txt -t 6
 ```
 
 ### Build documentation

--- a/opensir-cli
+++ b/opensir-cli
@@ -4,6 +4,7 @@
 import argparse
 import ast
 import sys
+import toml
 import numpy as np
 from opensir.models import SIR, SIRX
 
@@ -13,15 +14,26 @@ MODEL_SIRX = 1
 
 def run_cli():
     """ This function runs the main CLI routine """
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="""
+    Run SIR or SIR-X model given a set of initial conditions and model
+    parameters.
+    
+    """)
     parser.add_argument("-m", "--model", default="sir", choices=["sir", "sirx"])
-    parser.add_argument("-p", "--parameters", required=True)
-    parser.add_argument("-i", "--initial-conds", required=True)
-    parser.add_argument("-t", "--time", type=int)
+    parser.add_argument("-t", "--time", type=int, help = "Number of days for "
+    "the simulation")
+    parser.add_argument("-f", "--file", type=str, help = "Name of the "
+    "input file. If missing, the input file is read from STDIN")
 
     args = parser.parse_args()
-    p = np.array(ast.literal_eval(args.parameters))
-    w0 = np.array(ast.literal_eval(args.initial_conds))
+    if args.file == None:
+        data = toml.loads(sys.stdin.read())
+    else:
+        data = toml.load(args.file)
+
+    ic = data["initial_conds"]
+    params= data["parameters"]
+
     model = MODEL_SIR if args.model == "sir" else MODEL_SIRX
     kwargs = {}
 
@@ -29,8 +41,13 @@ def run_cli():
         kwargs["tf_days"] = args.time
 
     if model == MODEL_SIR:
+        p = [params["alpha"], params["beta"]]
+        w0 = [ic["S0"], ic["I0"], ic["R0"]]
         sol = SIR()
     else:
+        p = [params["alpha"], params["beta"], params["kappa_0"],
+             params["kappa"]]
+        w0 = [ic["S0"], ic["I0"], ic["R0"], ic["X0"]]
         sol = SIRX()
 
     sol.set_params(p, w0).solve(**kwargs).export(sys.stdout)

--- a/opensir-cli
+++ b/opensir-cli
@@ -2,10 +2,8 @@
 # pylint: disable=C0103
 """ Open-SIR CLI implementation """
 import argparse
-import ast
 import sys
 import toml
-import numpy as np
 from opensir.models import SIR, SIRX
 
 MODEL_SIR = 0
@@ -20,19 +18,23 @@ def run_cli():
     
     """)
     parser.add_argument("-m", "--model", default="sir", choices=["sir", "sirx"])
-    parser.add_argument("-t", "--time", type=int, help = "Number of days for "
-    "the simulation")
-    parser.add_argument("-f", "--file", type=str, help = "Name of the "
-    "input file. If missing, the input file is read from STDIN")
+    parser.add_argument("-t", "--time", type=int, help="Number of days for "
+                        "the simulation")
+    parser.add_argument("-f", "--file", type=str, help="Name of the "
+                        "input file. If missing, the input file is read from STDIN")
+    parser.add_argument("-s", "--suppress_header", action="store_true",
+                        help="Suppress CSV header")
+    parser.add_argument("-d", "--delimiter", type=str, help="CSV delimiter",
+                        default=",")
 
     args = parser.parse_args()
-    if args.file == None:
+    if args.file is None:
         data = toml.loads(sys.stdin.read())
     else:
         data = toml.load(args.file)
 
     ic = data["initial_conds"]
-    params= data["parameters"]
+    params = data["parameters"]
 
     model = MODEL_SIR if args.model == "sir" else MODEL_SIRX
     kwargs = {}
@@ -50,7 +52,9 @@ def run_cli():
         w0 = [ic["S0"], ic["I0"], ic["R0"], ic["X0"]]
         sol = SIRX()
 
-    sol.set_params(p, w0).solve(**kwargs).export(sys.stdout)
+    sol.set_params(p, w0).solve(**kwargs).export(sys.stdout,
+                                                 suppress_header=args.suppress_header,
+                                                 delimiter=args.delimiter)
 
 
 if __name__ == "__main__":

--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -67,7 +67,7 @@ class Model:
         self.w0 = initial_conds / self.pop
         return self
 
-    def export(self, f, delimiter=","):
+    def export(self, f, suppress_header=False, delimiter=","):
         """ Export the output of the model in CSV format.
 
         Note:
@@ -75,12 +75,19 @@ class Model:
 
         Args:
             f: file name or descriptor
+            suppress_header (boolean): Set to true to suppress the CSV header
             delimiter (str): delimiter of the CSV file
         """
         if self.sol is None:
             raise Exception("Missing call to solve()")
 
-        np.savetxt(f, self.sol, header=",".join(self.__class__.CSV_ROW), delimiter=",")
+        kwargs = {"delimiter": delimiter}
+
+        if not suppress_header:
+            kwargs["comments"] = ''
+            kwargs["header"] = ",".join(self.__class__.CSV_ROW)
+
+        np.savetxt(f, self.sol, **kwargs)
 
     def fetch(self):
         """ Fetch the data from the model.

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
           'scipy',
           'sklearn',
           'numpy',
+          'toml',
     ],
     long_description=read('README.md'),
     classifiers=[


### PR DESCRIPTION
This PR:
- Changes the old "ugly" input format to receive a TOML input file
- Adds "suppress header" and "delimiter" for formatting the CSV output.

```
usage: opensir-cli [-h] [-m {sir,sirx}] [-t TIME] [-f FILE] [-s] [-d DELIMITER]

Run SIR or SIR-X model given a set of initial conditions and model parameters.

optional arguments:
  -h, --help            show this help message and exit
  -m {sir,sirx}, --model {sir,sirx}
  -t TIME, --time TIME  Number of days for the simulation
  -f FILE, --file FILE  Name of the input file. If missing, the input file is read from STDIN
  -s, --suppress_header
                        Suppress CSV header
  -d DELIMITER, --delimiter DELIMITER
                        CSV delimiter
```

The input file is a TOML file with the following format

```
[initial_conds]
<cond> = value

[parameters]
<paran> = value
```

For instance, the following data is valid for running the SIR model with
alpha=0.95, beta=0.38 and initial conditions S0=341555, I0=445 and R0=0

```
[initial_conds]
S0 = 341555
I0 = 445
R0 = 0

[parameters]
alpha = 0.95
beta = 0.38
```

Then, it's possible to run the model with T=6 days:

```
opensir-cli --model sir --time 6 --file input_file.txt
```

Or reading the input file from STDIN:

```
cat input_file | opensir-cli --model sir --time 6
```