### PR TITLE
feat(model): extend fit to SIR-X 

### DIFF
--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -37,6 +37,8 @@ class Model:
         self.pop = None
         self.w0 = None
         self.pcov = None
+        self.fit_input = None
+        self.name = None
 
     @property
     def _model(self):
@@ -145,12 +147,20 @@ class Model:
             params = np.array(self.p)
             params[fit_index] = par_fit
             self.p = params
-            i_mod = call_solver(self._model, self.p, self.w0, t)
-            return i_mod[:, 2] * pop
+            # SIR-X special fitting of initial conditions
+            if self.name == "sirx":
+                # Estimate initial number of infected from reported: i_0=p[4]*x_0
+                self.w0[1] = self.p[4]*self.w0[3]
+                # Constrain parameters to be non negative
+            sol_mod = call_solver(self._model, self.p, self.w0, t)
+            return sol_mod[:, self.fit_input] * pop
 
         # Fit parameters
+        # Ensure non-negativity and a loose upper bound
+        bounds = (np.zeros(len(fit_params0)), np.ones(len(fit_params0))*100)
+
         par_opt, pcov = curve_fit(
-            f=function_handle, xdata=t_obs, ydata=n_i_obs, p0=fit_params0
+            f=function_handle, xdata=t_obs, ydata=n_i_obs, p0=fit_params0, bounds=bounds
         )
         self.p[fit_index] = par_opt
         self.pcov = pcov  # This also flags that the model was fitted

--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -30,6 +30,7 @@ class Model:
     CSV_ROW = []
     NUM_PARAMS = 4
     NUM_IC = 4
+    NAME = None
 
     def __init__(self):
         self.sol = None
@@ -38,7 +39,6 @@ class Model:
         self.w0 = None
         self.pcov = None
         self.fit_input = None
-        self.name = None
 
     @property
     def _model(self):

--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -147,22 +147,21 @@ class Model:
             params = np.array(self.p)
             params[fit_index] = par_fit
             self.p = params
-            # SIR-X special fitting of initial conditions
-            if self.name == "sirx":
-                # Estimate initial number of infected from reported: i_0=p[4]*x_0
-                self.w0[1] = self.p[4]*self.w0[3]
-                # Constrain parameters to be non negative
+            self._update_ic() # Updates IC if necessary. For example, i_o/x_0 for SIR-X
             sol_mod = call_solver(self._model, self.p, self.w0, t)
             return sol_mod[:, self.fit_input] * pop
 
         # Fit parameters
         # Ensure non-negativity and a loose upper bound
         bounds = (np.zeros(len(fit_params0)), np.ones(len(fit_params0))*100)
-
+        # return p_new, pcov
         par_opt, pcov = curve_fit(
             f=function_handle, xdata=t_obs, ydata=n_i_obs, p0=fit_params0, bounds=bounds
         )
         self.p[fit_index] = par_opt
         self.pcov = pcov  # This also flags that the model was fitted
         return self
-        # return p_new, pcov
+
+    def _update_ic(self):
+        """ updates initial conditions if necessary """
+        return self

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -62,6 +62,8 @@ class SIR(Model):
             SIR: reference to self
         """
         self._set_params(p, initial_conds)
+        self.name = 'sir'
+        self.fit_input = 2 # By default, fit against infected
         return self
 
     @property

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -34,6 +34,7 @@ class SIR(Model):
     CSV_ROW = ["Days", "S", "I", "R"]
     NUM_PARAMS = 2
     NUM_IC = 3
+    NAME = "SIR"
 
     def set_params(self, p, initial_conds):
         """ Set model parameters.
@@ -61,9 +62,13 @@ class SIR(Model):
         Returns:
             SIR: reference to self
         """
+
         self._set_params(p, initial_conds)
-        self.name = 'sir'
         self.fit_input = 2 # By default, fit against infected
+        return self
+
+    def _update_ic(self):
+        """Updates initial conditions if necessary"""
         return self
 
     @property

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -48,6 +48,7 @@ class SIRX(Model):
     CSV_ROW = ["Days", "S", "I", "R", "X"]
     NUM_PARAMS = 5
     NUM_IC = 4
+    NAME = "SIRX"
 
     def set_params(self, p, initial_conds):
         """ Set model parameters.
@@ -78,9 +79,13 @@ class SIRX(Model):
             SIRX: Reference to self
         """
         self._set_params(p, initial_conds)
-        self.name = 'sirx'
         self.fit_input = 4 # By default, fit against containment compartment X
         return self
+
+    def _update_ic(self):
+        """Updates i_0 = (i_0/x_0)*x_0 in the context
+        of parameter fitting"""
+        self.w0[1] = self.p[4]*self.w0[3]
 
     @property
     def _model(self):

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -28,8 +28,12 @@ def sirx(w, t, p):
     """
     # unpack state variable
     s, i, r, x = w  # pylint: disable=W0612
-    # unpack parameter
-    alpha, beta, kappa_0, kappa, inf_over_test = p # pylint: disable=W0612
+    # unpack parameters
+    alpha = p[0]
+    beta = p[1]
+    kappa_0 = p[2]
+    kappa = p[3]# pylint: disable=W0612
+    # Define ODE system
     ds_dt = -alpha * s * i - kappa_0 * s
     di_dt = alpha * s * i - beta * i - kappa_0 * i - kappa * i
     dr_dt = beta * i + kappa_0 * s

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -16,7 +16,7 @@ def sirx(w, t, p):
         X: Fraction of the population that is quarantined
 
     t: time
-    p: vector of parametersÑ
+    p: vector of parameters
 
         alpha: transmission rate
         beta: recovery / removal rate


### PR DESCRIPTION
This pull request enhances the model.fit() function in terms of its
accuracy and robustness:

In model.py, an special case for optimization is included for
the SIR-X model. One of the model parameters is the initial ratio
between infected and tested individuals, i_0/x_0. This is fitted
and require a slightly more careful treatment than traditional
parameter fitting. You can see the implementation on model.py fit

As I discovered this fifth parameter of sirx, I modified the sirx.py
class increasing the number of parameters to 5 and unpacking them
properly. Additionally, I included interesting quantities mentioned
in the paper of Maier et al (2020) such as the public containment
leverage P and the probability of quarantined Q. An effective r_0
and T_I are also defined. All of this was implemented as properties
in sirx.

I included two more attributes on SIR and SIR-X:
- name: this enables the fit() function to adjust the procedure
for the SIR or SIR-X (and will be helpful to extend for any other model)
- fit_input: Although SIR fits "I" directly from the number of
observed cases, SIR-X fits "X" to the observed cases and calculates I.
To specify to which index of the model outputs the input data should
be fitted, the fit_input is a property that the user can control.
By default, fit_input = 2 for SIR and fit_input = 4 for SIR-X