### PR TITLE
docs(sphinx): fix autoclass directives

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -10,11 +10,11 @@ Welcome to Open-SIR's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-.. autoclass:: models.SIR
+.. autoclass:: opensir.models.SIR
    :members:
    :inherited-members:
 
-.. autoclass:: models.SIRX
+.. autoclass:: opensir.models.SIRX
    :members:
    :inherited-members:
 


### PR DESCRIPTION
This commit fixes the autoclass directives of the root Sphinx file.
They were pointing to "models.xxx" instead of "opensir.models.xxx"