### PR TITLE
chore(sphinx): turn doc build warnings into errors

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,4 +27,4 @@ allow_prereleases = true
 start = "python opensir-cli"
 lint = "pylint **/*.py"
 test = "pytest"
-doc = "sphinx-build -M html . _build"
+doc = "sphinx-build -M html . _build -W"


### PR DESCRIPTION
This commit turns all `sphinx-build` warnings into errors.
The CI will now complain if the documentation is not build properly.

Without this commit, the `sphinx-build` exits with a successful error
code