### PR TITLE
model.py: Add checking on params and tests

### DIFF
--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -54,7 +54,7 @@ class Model:
     def _model(self):
         raise Exception()
 
-    def _set_params(self, p, initial_conds):
+    def set_params(self, p, initial_conds):
         """ Set model parameters.
         Args:
             p (list): parameters of the model. The parameters units are 1/day,

--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -40,6 +40,16 @@ class Model:
         self.pcov = None
         self.fit_input = None
 
+    class InvalidParameterError(Exception):
+        """Raised when an initial parameter of a value is not correct"""
+
+        pass
+
+    class InvalidNumberOfParametersError(Exception):
+        """Raised when the number of initial parameters is not correct"""
+
+        pass
+
     @property
     def _model(self):
         raise Exception()
@@ -47,7 +57,8 @@ class Model:
     def _set_params(self, p, initial_conds):
         """ Set model parameters.
         Args:
-            p (list): parameters of the model. The parameters units are 1/day.
+            p (list): parameters of the model. The parameters units are 1/day,
+                      and should be >= 0.
             initial_conds (list): Initial conditions, in total number of individuals.
             For instance, S0 = n_S0/population, where n_S0 is the number of subjects
             who are susceptible to the disease.
@@ -59,11 +70,15 @@ class Model:
         num_params = self.__class__.NUM_PARAMS
         num_ic = self.__class__.NUM_IC
 
+        try:
+            for param in p:
+                assert param > 0
+        except:
+            raise self.InvalidParameterError()
+
         if len(p) != num_params or len(initial_conds) != num_ic:
-            raise Exception(
-                "Invalid number of parameters \
-                             or initial conditions"
-            )
+            raise self.InvalidNumberOfParametersError()
+
         self.p = p
         self.pop = np.sum(initial_conds)
         self.w0 = initial_conds / self.pop

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -63,7 +63,7 @@ class SIR(Model):
             SIR: reference to self
         """
 
-        self._set_params(p, initial_conds)
+        super().set_params(p, initial_conds)
         self.fit_input = 2  # By default, fit against infected
         return self
 

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -78,7 +78,7 @@ class SIRX(Model):
         Returns:
             SIRX: Reference to self
         """
-        self._set_params(p, initial_conds)
+        super().set_params(p, initial_conds)
         self.fit_input = 4  # By default, fit against containment compartment X
         return self
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,36 @@
+# pylint: disable=no-self-use
+"Test exponential convergence"
+import pytest
+from opensir.models import Model
+
+
+class TestModel:
+    """ Test class for the base Model """
+
+    @pytest.fixture
+    def model(self):
+        """Model fixture object used by all tests"""
+        return Model()
+
+    def test_invalid_params_should_raise(self, model):
+        """Tests that initializing the model with invalid params raises an
+            exception.
+        """
+        p = [-1, 2, 3, 4]
+        ic = [5, 6, 7, 8]
+
+        with pytest.raises(Model.InvalidParameterError):
+            model.set_params(p, ic)
+
+    def test_invalid_number_params_should_raise(self, model):
+        """Tests that initializing the model with invalid number of parameters
+           or initial conditions raises an exception.
+        """
+        p = [1, 2, 3, 4]
+        ic = [5, 6, 7, 8]
+
+        with pytest.raises(Model.InvalidNumberOfParametersError):
+            model.set_params([], ic)
+
+        with pytest.raises(Model.InvalidNumberOfParametersError):
+            model.set_params(p, [])


### PR DESCRIPTION
This adds a check on the `set_params` method, to verify the correctness of the parameters. Also, I added some custom exceptions to raise on these cases.

I added just some simple tests on this. I changed `_set_params` to `set_params` and override that on the children, so testing can be done on the base model.