### PR TITLE
fix: make setup.py windows compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,34 @@
-import os
+""" Python setup configuration file for Open-SIR"""
 from setuptools import setup
-
-# Utility function to read the README file.
-# Used for the long_description.  It's nice, because now 1) we have a top level
-# README file and 2) it's easier to type in the README file than to put a raw
-# string in below ...
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
 
 setup(
     name="opensir",
     version="1.0.0",
     author="Open-SIR community",
     author_email="open.sir.project@gmail.com",
-    description=(
-        "Open-SIR is an Open Source Python project for modelling"
-        "pandemics and infectious diseases using Compartmental"
-        "Models"
-    ),
+    description=("Open-SIR is an Open Source Python project for modelling"
+                 " pandemics and infectious diseases using Compartmental"
+                 " Models"),
     license="MIT",
     keywords="SIR SIRX pandemics modelling",
     url="http://github.com/open-sir/open-sir",
-    packages=["opensir", "opensir.models"],
+    packages=['opensir', 'opensir.models'],
     scripts=["opensir-cli"],
-    install_requires=["scipy", "sklearn", "numpy", "toml",],
-    long_description=read("README.md"),
+    install_requires=[
+        'scipy',
+        'sklearn',
+        'numpy',
+        'toml',
+    ],
+    long_description=("Open-SIR is an Open Source Python project for"
+                      " modelling epidemics like COVID-19"
+                      " using Compartmental Models, such as the widely used"
+                      " Susceptible-Infected-Removed (SIR model)"
+                      " Features:"
+                      " Model the dynamics of infectious diseases, parameter fitting,"
+                      " calculation of confidence intervals,"
+                      " CLI for interfacing with non Python environments such as"
+                      " Bash, Node.JS, Matlab, etc."),
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Topic :: Utilities",

--- a/setup.py
+++ b/setup.py
@@ -6,29 +6,28 @@ setup(
     version="1.0.0",
     author="Open-SIR community",
     author_email="open.sir.project@gmail.com",
-    description=("Open-SIR is an Open Source Python project for modelling"
-                 " pandemics and infectious diseases using Compartmental"
-                 " Models"),
+    description=(
+        "Open-SIR is an Open Source Python project for modelling"
+        " pandemics and infectious diseases using Compartmental"
+        " Models"
+    ),
     license="MIT",
     keywords="SIR SIRX pandemics modelling",
     url="http://github.com/open-sir/open-sir",
-    packages=['opensir', 'opensir.models'],
+    packages=["opensir", "opensir.models"],
     scripts=["opensir-cli"],
-    install_requires=[
-        'scipy',
-        'sklearn',
-        'numpy',
-        'toml',
-    ],
-    long_description=("Open-SIR is an Open Source Python project for"
-                      " modelling epidemics like COVID-19"
-                      " using Compartmental Models, such as the widely used"
-                      " Susceptible-Infected-Removed (SIR model)"
-                      " Features:"
-                      " Model the dynamics of infectious diseases, parameter fitting,"
-                      " calculation of confidence intervals,"
-                      " CLI for interfacing with non Python environments such as"
-                      " Bash, Node.JS, Matlab, etc."),
+    install_requires=["scipy", "sklearn", "numpy", "toml",],
+    long_description=(
+        "Open-SIR is an Open Source Python project for"
+        " modelling epidemics like COVID-19"
+        " using Compartmental Models, such as the widely used"
+        " Susceptible-Infected-Removed (SIR model)"
+        " Features:"
+        " Model the dynamics of infectious diseases, parameter fitting,"
+        " calculation of confidence intervals,"
+        " CLI for interfacing with non Python environments such as"
+        " Bash, Node.JS, Matlab, etc."
+    ),
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Topic :: Utilities",


### PR DESCRIPTION
I really liked the implementation of @jia200x of the full readme to be linked with the setup.py. Unfortunately, as readme.MD has an encoding non-compatible with Windows (PS or CMD), it was preventing the success of pip install .

In the commit:

- Deleted read() function
- Added a "longer" description. Not sure how long this has to be. If anyone is not happy with it and can provide an example of a good one I am happy to extend.

Fixes #44