### PR TITLE
nbsphinx: add Sphinx plugin to show Jupyter notebooks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
       - bootstrap
       - run:
           name: Build docs
-          command: pipenv run doc
+          command: sudo apt-get update && sudo apt-get install pandoc && pipenv run doc
 
   build:
     description: Build Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /usr/src/app
 
 COPY Pipfile Pipfile.lock ./
 
-RUN apt-get update && pip3 install pipenv && pipenv install
+RUN apt-get update && apt-get install pandoc -y && pip3 install pipenv && pipenv install
 
 COPY . .
 

--- a/Pipfile
+++ b/Pipfile
@@ -30,6 +30,6 @@ allow_prereleases = true
 start = "python opensir-cli"
 lint = "pylint **/*.py"
 test = "pytest"
-doc = "sphinx-build -M html doc doc/build -W"
+doc = "sphinx-build -M html . doc/build -W"
 black = "black ."
 black_check = "black --check ."

--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ sphinx = "*"
 sphinx-rtd-theme = "*"
 toml = "*"
 pandas = "*"
+nbsphinx = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dc8cb6e94ba2025fc67821b6fdf536d117d4bd5d4cdaaccc7293472af45bcaa9"
+            "sha256": "58f9e6e4ae0e98386eb4afeb0efcb1fc47ad91a4cdda639a9d9d3c2625de5ba4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -71,14 +71,6 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
-                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.3"
         },
         "cycler": {
             "hashes": [
@@ -326,6 +318,14 @@
             ],
             "version": "==5.0.5"
         },
+        "nbsphinx": {
+            "hashes": [
+                "sha256:bc8ce94b00622e2d8fff61338c68734bf0d68dec844b70a8317e6fad7e619783",
+                "sha256:cf44b8675596fea7320f460f676fee26c8b3ee91140f80e41a77a46272af0081"
+            ],
+            "index": "pypi",
+            "version": "==0.6.0"
+        },
         "nest-asyncio": {
             "hashes": [
                 "sha256:14e194b72144052a82173ca9109bd07c57813a320f42c7acfad1e4d329988350",
@@ -409,6 +409,14 @@
             ],
             "version": "==0.6.2"
         },
+        "pexpect": {
+            "hashes": [
+                "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
+                "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
+            ],
+            "markers": "sys_platform != 'win32'",
+            "version": "==4.8.0"
+        },
         "pickleshare": {
             "hashes": [
                 "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
@@ -428,6 +436,14 @@
                 "sha256:df7e9e63aea609b1da3a65641ceaf5bc7d05e0a04de5bd45d05dbeffbabf9e04"
             ],
             "version": "==3.0.5"
+        },
+        "ptyprocess": {
+            "hashes": [
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
+            ],
+            "markers": "os_name != 'nt'",
+            "version": "==0.6.0"
         },
         "pygments": {
             "hashes": [
@@ -462,40 +478,6 @@
                 "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
             ],
             "version": "==2019.3"
-        },
-        "pywin32": {
-            "hashes": [
-                "sha256:300a2db938e98c3e7e2093e4491439e62287d0d493fe07cce110db070b54c0be",
-                "sha256:31f88a89139cb2adc40f8f0e65ee56a8c585f629974f9e07622ba80199057511",
-                "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0",
-                "sha256:47a3c7551376a865dd8d095a98deba954a98f326c6fe3c72d8726ca6e6b15507",
-                "sha256:4cdad3e84191194ea6d0dd1b1b9bdda574ff563177d2adf2b4efec2a244fa116",
-                "sha256:7c1ae32c489dc012930787f06244426f8356e129184a02c25aef163917ce158e",
-                "sha256:7f18199fbf29ca99dff10e1f09451582ae9e372a892ff03a28528a24d55875bc",
-                "sha256:9b31e009564fb95db160f154e2aa195ed66bcc4c058ed72850d047141b36f3a2",
-                "sha256:a929a4af626e530383a579431b70e512e736e9588106715215bf685a3ea508d4",
-                "sha256:c054c52ba46e7eb6b7d7dfae4dbd987a1bb48ee86debe3f245a2884ece46e295",
-                "sha256:f27cec5e7f588c3d1051651830ecc00294f90728d19c3bf6916e6dba93ea357c",
-                "sha256:f4c5be1a293bae0076d93c88f37ee8da68136744588bc5e2be2f299a34ceb7aa"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==227"
-        },
-        "pywinpty": {
-            "hashes": [
-                "sha256:1e525a4de05e72016a7af27836d512db67d06a015aeaf2fa0180f8e6a039b3c2",
-                "sha256:2740eeeb59297593a0d3f762269b01d0285c1b829d6827445fcd348fb47f7e70",
-                "sha256:2d7e9c881638a72ffdca3f5417dd1563b60f603e1b43e5895674c2a1b01f95a0",
-                "sha256:33df97f79843b2b8b8bc5c7aaf54adec08cc1bae94ee99dfb1a93c7a67704d95",
-                "sha256:5fb2c6c6819491b216f78acc2c521b9df21e0f53b9a399d58a5c151a3c4e2a2d",
-                "sha256:8fc5019ff3efb4f13708bd3b5ad327589c1a554cb516d792527361525a7cb78c",
-                "sha256:b358cb552c0f6baf790de375fab96524a0498c9df83489b8c23f7f08795e966b",
-                "sha256:dbd838de92de1d4ebf0dce9d4d5e4fc38d0b7b1de837947a18b57a882f219139",
-                "sha256:dd22c8efacf600730abe4a46c1388355ce0d4ab75dc79b15d23a7bd87bf05b48",
-                "sha256:e854211df55d107f0edfda8a80b39dfc87015bef52a8fe6594eb379240d81df2"
-            ],
-            "markers": "os_name == 'nt'",
-            "version": "==0.5.7"
         },
         "pyzmq": {
             "hashes": [
@@ -784,14 +766,6 @@
             ],
             "version": "==2.3.3"
         },
-        "atomicwrites": {
-            "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==1.3.0"
-        },
         "attrs": {
             "hashes": [
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
@@ -813,14 +787,6 @@
                 "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
             ],
             "version": "==7.1.1"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
-                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.3"
         },
         "importlib-metadata": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ pipenv run start -i input_file.txt -t 6
 ### Build documentation
 
 Build the Sphinx documentation out of the open-sir Pipenv environment.
+Note: `pandoc` is required in order to build the documentation. See
+[installation notes](https://pandoc.org/installing.html)
+
 ```
 pipenv run doc
 ```

--- a/SIR.ipynb
+++ b/SIR.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Modelling pandemics using compartmental models\n",
+    "# Modelling pandemics using compartmental models\n",
     "\n",
     "Coronavirus COVID-19 is a pandemic that is spreading quickly worlwide. Up to the 29th of March, there are 666,211 cases confirmed, 30,864 deaths and 141,789 recovered people worldwide. Governments and citizens are taking quick decisions to limit the spread of the virus and minimize the number of infected and deaths. These decisions are taken based on the experts opinion, which justify their claims based in the results of predictive models.\n",
     "\n",
     "\n",
     "This Jupyter Notebook is an effort to decrease the access barriers to state of the art yet simple models that can be used to take public policy decisions to limit disease spread and save lives. \n",
     "\n",
-    "### SIR model\n",
+    "## SIR model\n",
     "\n",
     "Most epidemic models share a common approach on modelling the spread of a disease. The SIR model is a simple deterministic compartmental model to predict disease spread. An objective population is divided in three groups: the susceptible ($S$), the infected ($I$) and the recovered or removed ($R$). These quantities enter the model as fractions of the total population $P$:\n",
     "\n",
@@ -24,7 +24,7 @@
     "\n",
     "As a pandemics infects and kills much more quickly than human natural rates of birth and death, the population size is assumed constant except for the individuals that recover or die. Hence, $S+I+R=P/P=1$. The pandemics dynamics is modelled as a system of ordinary differential equations which governs the rate of change at which the percentage of susceptible, infected and recovered/removed individuals in a population evolve.\n",
     "\n",
-    "The number of possible transmissions is proportional to the number of interactions between the susceptible and infected populations, $S \\times I $:\n",
+    "The number of possible transmissions is proportional to the number of interactions between the susceptible and infected populations, `$S \\times I $`:\n",
     "\n",
     "$$\\frac{dS}{dt} = -\\alpha SI.$$\n",
     "\n",
@@ -35,9 +35,9 @@
     "$$\\frac{dI}{dt} = \\alpha S I  - \\beta I, $$\n",
     "$$\\frac{dR}{dt} = \\beta I. $$\n",
     "\n",
-    "Where $ \\beta $ is the percentage of the infected population that is removed from the transmission process per day.\n",
+    "Where `$ \\beta $` is the percentage of the infected population that is removed from the transmission process per day.\n",
     "\n",
-    "In early stages of the infection, the number of infected people is much lower than the susceptible populations. Hence, $S \\approx 1$ making $dI/dt$ linear and the system has the analytical solution $I(t) = I_0 \\exp (\\alpha - \\beta)t$.\n",
+    "In early stages of the infection, the number of infected people is much lower than the susceptible populations. Hence, `$S \\approx 1$` making `$dI/dt$` linear and the system has the analytical solution `$I(t) = I_0 \\exp (\\alpha - \\beta)t$`.\n",
     "\n"
    ]
   },
@@ -45,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Numerical implementation - SIR model\n",
+    "### Numerical implementation - SIR model\n",
     "\n",
     "Three python packages are imported: numpy for numerical computing, matplotlib.pyplot for visualization and the numerical integration routine odeint from scipy.integrate:"
    ]
@@ -86,7 +86,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### SIR-X model\n",
+    "## SIR-X model\n",
     "\n",
     "A new epidemic model based in SIR, SIRX, was developed by the [Robert Koch Institut](http://rocs.hu-berlin.de/corona/docs/forecast/model/#sir-x-dynamics-outbreaks-with-temporally-increasing-interventions) and is implemented in what follows. A full description of the model is available in the [Robert Koch Institut SIRX model webiste](http://rocs.hu-berlin.de/corona/docs/forecast/model/#sir-x-dynamics-outbreaks-with-temporally-increasing-interventions).\n",
     "\n",
@@ -97,15 +97,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Usage example\n",
+    "## Usage example\n",
     "\n",
     "\n",
     "\n",
-    "#### Case study\n",
+    "### Case study\n",
     "\n",
     "The borough of Ealing, in London, is selected arbitrarly as one of the authors is living there at the moment. According to the UK office for National Statistics, the population of Ealing by mid-year 2018 is [342,000](https://www.ealing.gov.uk/info/201048/ealing_facts_and_figures/2184/population_and_households/1). The number of reported infections at 29/03/2020 is 241.\n",
     "\n",
-    "#### Model parameters\n",
+    "### Model parameters\n",
     "As an implementation examples, the parameter $\\beta$ is estimated from the methodology followed by the [Robert Koch Institut SIRX model webiste](http://rocs.hu-berlin.de/corona/docs/forecast/model/#sir-x-dynamics-outbreaks-with-temporally-increasing-interventions). The institute estimated the a removal rate value $\\beta = 0.38/d$ (mean infections time $T_I = 1/\\beta = 2.6d)$ based on one third of the reported average infections preioud of moderate cases in Mainland China.\n",
     "\n",
     "The reproduction number is fixed $R_0 = \\alpha / \\beta = 2.5$ as a first approximation. \n",
@@ -144,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Calculate model parameters and initial conditions"
+    "### Calculate model parameters and initial conditions"
    ]
   },
   {
@@ -169,7 +169,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Build the model with the default parameters and predict the number of susceptible, infected and recovered people in the Ealing borough.\n"
+    "### Build the model with the default parameters and predict the number of susceptible, infected and recovered people in the Ealing borough."
    ]
   },
   {
@@ -190,7 +190,7 @@
     "# Initialize an emplty SIR model\n",
     "my_SIR = SIR()\n",
     "# Set model parameters\n",
-    "my_SIR._set_params(p=params,initial_conds=w0)\n",
+    "my_SIR.set_params(p=params,initial_conds=w0)\n",
     "\n",
     "# Call model.solve functions with the time in days and the number of points\n",
     "# as the number of days\n",
@@ -264,9 +264,10 @@
    "metadata": {},
    "source": [
     "## DANGER ZONE\n",
-    "### Example: predict the total number of infections and the time where the number of infected people is maximum\n",
     "\n",
-    "This is extremely dangerous as $R_0$ is extremely likely to change with time. However we have seen many people taking decisions in this kind of analysis. Use it at your own risk and with a metric ton of salt."
+    "This is extremely dangerous as $R_0$ is extremely likely to change with time. However we have seen many people taking decisions in this kind of analysis. Use it at your own risk and with a metric ton of salt.\n",
+    "\n",
+    "### Example: predict the total number of infections and the time where the number of infected people is maximum\n"
    ]
   },
   {
@@ -475,8 +476,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Calculate confidence intervals\n",
-    "\n"
+    "### Calculate confidence intervals"
    ]
   },
   {
@@ -485,7 +485,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from models import ci_bootstrap, ci_block_cv\n",
+    "from opensir.models import ci_bootstrap, ci_block_cv\n",
     "\n",
     "# Get the confidence interval through random bootstrap\n",
     "# Define bootstrap options\n",
@@ -647,13 +647,6 @@
     "plt.title(\"Block bootstrapping change in MSE\")\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/conf.py
+++ b/conf.py
@@ -48,6 +48,7 @@ exclude_patterns = [
     ".DS_Store",
     ".ipynb_checkpoints",
     "doc/build",
+    "tutorials",
 ]
 
 

--- a/conf.py
+++ b/conf.py
@@ -15,6 +15,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath("."))
 
 
@@ -41,8 +42,13 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".ipynb_checkpoints",
-                    "doc/build"]
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    ".ipynb_checkpoints",
+    "doc/build",
+]
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/conf.py
+++ b/conf.py
@@ -15,8 +15,7 @@
 #
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("."))
 
 
 # -- Project information -----------------------------------------------------
@@ -42,7 +41,8 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".ipynb_checkpoints",
+                    "doc/build"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -55,4 +55,4 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = ["doc/_static"]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,7 +34,7 @@ release = "1.0.0"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "nbsphinx"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/index.rst
+++ b/index.rst
@@ -34,6 +34,7 @@ from the `Robert Koch Institut
 
    doc/getting-started
    doc/API
+   SIR
 
 Indices and tables
 ==================

--- a/index.rst
+++ b/index.rst
@@ -32,8 +32,8 @@ from the `Robert Koch Institut
    :maxdepth: 2
    :caption: Contents:
 
-   getting-started
-   API
+   doc/getting-started
+   doc/API
 
 Indices and tables
 ==================


### PR DESCRIPTION
This PR:
- Adds the `nbsphinx` plugin to include Jupyter notebooks in Sphinx documentation
- Move the `index.rst` and `conf.py` to the root directory (unfortunately we will need to do this until someone finds a cleaner approach to import opensir outside of the root directory)
- Fix some style and import issues in the Jupyter notebook
- Include the notebook from Sphinx
- Add `pandoc` to Dockerfile (required by nbsphinx)

This indirectly adds some tests for Jupyter notebooks. If there's something wrong (style issues or wrong python code) then the documentation won't build (and CircleCI will complain)

Test with:
```
pipenv run doc
firefox doc/build/html
```