### PR TITLE
setup.py: Specify encoding for long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ from setuptools import setup
 # README file and 2) it's easier to type in the README file than to put a raw
 # string in below ...
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    file_path = os.path.join(os.path.dirname(__file__), fname)
+    return open(file_path, encoding="utf-8").read()
 
 
 setup(


### PR DESCRIPTION
In #44 @felipehuerta17 reported that windows is not being able to read the `README.md` for the package long description. #52 proposes not using the file, but it seems that just indicating the encoding in `open` is enough to make it work.

On Windows:
- on the repo run `pip install .` -> it should succeed.

Fixes #44
Alternative to #52