### PR TITLE
doc: Add 'Read The Docs' configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+python:
+  version: 3.7
+  install:
+    - requirements: doc/requirements.txt
+    - method: pip
+      path: .

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 [mit]: https://img.shields.io/badge/License-MIT-blue.svg
 [circleci]: https://circleci.com/gh/open-sir/open-sir.svg?style=shield
 [black]: https://img.shields.io/badge/code%20style-black-000000.svg
+[rtd]: https://readthedocs.org/projects/open-sir/badge/?version=latest
 
 # open-sir
 
 [![License: MIT][mit]](https://opensource.org/licenses/MIT)
 [![open-sir][circleci]](https://circleci.com/gh/open-sir/open-sir)
 [![Code style: black][black]](https://github.com/psf/black)
+[![Documentation Status][rtd]](https://open-sir.readthedocs.io/en/latest)
+
 
 Open-SIR is an Open Source Python project for modelling pandemics and infectious diseases using Compartmental Models, such as the widely used [Susceptible-Infected-Removed (SIR) model](http://rocs.hu-berlin.de/corona/docs/forecast/model/#classic-sir-dynamics). 
 The current stage of the software is *Alpha*.
@@ -18,6 +21,9 @@ The current stage of the software is *Alpha*.
 - CLI for interfacing with non Python environments (Bash, Node.JS, Matlab, etc).
 
 So far, Open-SIR provides an implementation of the SIR model and the novel [SIR-X model, developed by Maier and Dirk](https://science.sciencemag.org/content/early/2020/04/07/science.abb4557.full) from the [Robert Koch Institut](http://rocs.hu-berlin.de/corona/docs/forecast/model/#sir-x-dynamics-outbreaks-with-temporally-increasing-interventions).
+
+For the API reference and examples of usage, please check the
+[online documentation](https://open-sir.readthedocs.io/).
 
 ### Dependencies
 

--- a/conf.py
+++ b/conf.py
@@ -51,6 +51,7 @@ exclude_patterns = [
     "tutorials",
 ]
 
+master_doc = "index"
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -91,7 +91,7 @@ Python API
 
 You can replicate the predictions of the CLI with the following python script:
 
-.. code-block::
+.. code-block:: python
 
     from opensir.models import SIR
     my_sir = SIR() # Initialize an empty SIR model

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,11 @@
+ipykernel
+numpy
+matplotlib
+pandas
+sphinxcontrib-bibtex
+sphinxcontrib-svg2pdfconverter
+ipywidgets
+sphinx-copybutton
+sphinx-gallery
+jupytext
+nbsphinx


### PR DESCRIPTION
This PR adds the configuration needed for Read The Docs. It also introduces minor fixes needed to make it work. The changes are the ones tested in [this test branch](https://github.com/open-sir/open-sir/tree/read_the_docs), which produce [this documentation](https://open-sir.readthedocs.io/en/read_the_docs/).

We can't directly test changes from the PR. So, for testing all changes are mirrored in `read_the_docs` branch, and the documentation is built automatically.