### PR TITLE
docs: include math description of models

### DIFF
--- a/doc/API.rst
+++ b/doc/API.rst
@@ -1,9 +1,71 @@
 Open-SIR API
 ============
 
+SIR Model
+*********
+
+Most epidemic models share a common approach on modelling the spread of a disease. 
+The susceptible-infectious-removed (SIR) model is a simple deterministic compartmental 
+model to predict disease spread. An objective population is divided in three groups: 
+the susceptible (:math:`S`), the infected (:math:`I`) and the recovered or removed (:math:`R`). 
+These quantities enter the model as fractions of the total population :math:`P`.
+
+.. math::
+   S = \frac{\text{Number of susceptible individuals}}{\text{Population size}},
+
+.. math::
+   I = \frac{\text{Number of infected individuals}}{\text{Population size}},
+
+.. math::
+   R = \frac{\text{Number of recovered or removed individuals}}{\text{Population size}},
+
+As a pandemics infects and kills much more quickly than human natural rates of birth and death, 
+the population size is assumed constant  except for the individuals that recover or die. 
+Hence, :math:`S+I+R=P/P=1`. The pandemics dynamics is modelled  as a system of ordinary differential equations
+which governs the rate of change at which the percentage of susceptible, infected 
+and recovered/removed individuals in a population evolve.
+
+The number of possible transmissions is proportional to the number of interactions between 
+the susceptible and infected compartments, :math:`S \times I`:
+
+.. math::
+   \frac{dS}{dt} = -\alpha SI,
+
+Where :math:`\alpha` / :math:`[\text{time}]^{-1}` is the transmission rate of the process which quantifies how 
+many of the interactions between susceptible and infected populations yield to new infections per day.
+
+The population of infected individuals will increase with new infections and decrease with recovered or removed people. 
+
+.. math::
+   \frac{dI}{dt} = \alpha S I  - \beta I,
+   
+.. math::
+   \frac{dR}{dt} = \beta I,
+
+Where :math:`\beta` is the percentage of the infected population that is removed from the transmission process per day.
+
+The infectious period, :math:`T_I` / :math:`[\text{time}]` , is defined as the reciprocal of the removal rate: 
+
+.. math::
+   T_I=\frac{1}{\beta}.
+
+In early stages of the infection, the number of infected people is much lower than the susceptible population. 
+Hence, :math:`S \approx 1` making :math:`dI/dt` linear and the system has the analytical solution
+:math:`I(t) = I_0 \exp (\alpha - \beta)t`.
+
+
 .. autoclass:: opensir.models.SIR
    :members:
    :inherited-members:
+
+SIR-X Model
+***********
+
+The SIR-X model extends the SIR model adding two parameters:
+the quarantine rate :math:`\kappa` and the containement rate 
+:math:`\kappa_0`. This extension allows the model to capture the
+"decrease" of susceptible population owing containment and quarantine
+measures.
 
 .. autoclass:: opensir.models.SIRX
    :members:

--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -137,19 +137,26 @@ class Model:
         """ Returns reproduction number
 
         Returns:
-            float: r0 (alpha/beta)
+            float:
+            .. math::
+                R_0 = \\alpha/\\beta
         """
         return self.p[0] / self.p[1]
 
     def fit(self, t_obs, n_i_obs, population, fit_index=None):
         """ Use the Levenberg-Marquardt algorithm to fit
-        the parameter alpha, as beta is assumed constant
+        model parameters consistent with True entries in the fit_index list.
 
         Args:
             t_obs (np.array): Vector of days corresponding to the observations
-            of number of infected people
+                of number of infected people
             n_i_obs (np.array): Vector of number of infected people
-            population: Size of the objective population
+            population (integer): Size of the objective population
+            fit_index (list of booleans , optional): this list must be
+                of the same size of the number of  parameters of the model.
+                The parameter p[i] will be fitted if fit_index[i] = True. Otherwise,
+                the parameter will be fixed. By default, fit will only fit the first
+                parameter of p, p[0].
 
         Returns:
             Model: Reference to self

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -93,20 +93,47 @@ class SIRX(Model):
 
     @property
     def t_inf_eff(self):
-        "Returns effective infectious period"
+        """Returns effective infectious period
+        
+        Returns:
+            float:
+            .. math::
+                T_{I,eff} = (\\beta + \\kappa + \\kappa_0)^{-1} 
+        """
         return 1 / sum(self.p[1:4])
 
     @property
     def r0_eff(self):
-        "Returns effective reproduction rate"
+        """Returns effective reproduction rate :math:`R_{0,eff}`
+        
+        Returns:
+            float:
+            .. math::
+                R_{0,eff} = \\alpha T_{I,eff}
+        
+        """
+
         return self.t_inf_eff * self.p[0]
 
     @property
     def pcl(self):
-        "Returns public containment leverage"
+        """Returns public containment leverage :math:`P`
+        
+        Returns:
+            float:
+            .. math::
+                P = \\frac{\\kappa_0}{\\kappa_0 + \\kappa}
+        
+        """
         return self.p[2] / (self.p[2] + self.p[3])
 
     @property
     def q_prob(self):
-        "Returns quarantine probability"
+        """ Returns quarantine probability :math:`Q`
+        
+        Returns:
+            float:
+            .. math::
+                Q = \\frac{\\kappa_0 + \\kappa}{\\beta + \\kappa_0 + \\kappa}
+        """
         return (self.p[2] + self.p[3]) / sum(self.p[1:4])


### PR DESCRIPTION
In this PR I start the discussion and visualization on how well the documents will look like when including model descriptions on API.rst.

As API.rst is linked to the index of the html

Copy this branch, do pipenv run doc and look the pretty equations and tell me what you think, whether this is in the good direction or not.

In the functions documentation I also included an RST notation following OpenFOAM style. 

The idea is to throw the first stone, and make many commits more here to update the docs