### PR TITLE
feat(model): add dict params to set_params function

### DIFF
--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -28,8 +28,8 @@ class Model:
     """ Base model definition """
 
     CSV_ROW = []
-    NUM_PARAMS = 4
-    NUM_IC = 4
+    PARAMS = []
+    IC = []
     NAME = None
 
     def __init__(self):
@@ -67,8 +67,17 @@ class Model:
             Model: Reference to self
         """
 
-        num_params = self.__class__.NUM_PARAMS
-        num_ic = self.__class__.NUM_IC
+        params = self.__class__.PARAMS
+        ic = self.__class__.IC
+
+        if type(p) is dict:
+            p = [p[d] for d in params if d in p.keys()]
+
+        if type(initial_conds) is dict:
+            initial_conds = [initial_conds[d] for d in ic if d in initial_conds.keys()]
+
+        num_params = len(params)
+        num_ic = len(ic)
 
         try:
             for param in p:

--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -57,18 +57,22 @@ class Model:
     def set_params(self, p, initial_conds):
         """ Set model parameters.
         Args:
-            p (list): parameters of the model. The parameters units are 1/day,
+            p (dict or list): parameters of the model. The parameters units are 1/day,
                       and should be >= 0.
-            initial_conds (list): Initial conditions, in total number of individuals.
+            initial_conds (dict or list): Initial conditions, in total number of individuals.
             For instance, S0 = n_S0/population, where n_S0 is the number of subjects
             who are susceptible to the disease.
+
+        Note:
+            Support for list of params and initial conditions will be deprecated
+            soon.
 
         Returns:
             Model: Reference to self
         """
 
-        params = self.__class__.PARAMS
-        ic = self.__class__.IC
+        params = self.PARAMS
+        ic = self.IC
 
         if type(p) is dict:
             p = [p[d] for d in params if d in p.keys()]
@@ -111,7 +115,7 @@ class Model:
 
         if not suppress_header:
             kwargs["comments"] = ""
-            kwargs["header"] = ",".join(self.__class__.CSV_ROW)
+            kwargs["header"] = ",".join(self.CSV_ROW)
 
         np.savetxt(f, self.sol, **kwargs)
 

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -32,16 +32,17 @@ class SIR(Model):
     """ SIR model definition """
 
     CSV_ROW = ["Days", "S", "I", "R"]
-    NUM_PARAMS = 2
-    NUM_IC = 3
+    PARAMS = ["alpha", "beta"]
+    IC = ["n_S0", "n_I0", "n_R0"]
     NAME = "SIR"
 
     def set_params(self, p, initial_conds):
         """ Set model parameters.
 
         Args:
-            p (list): parameters of the model [alpha, beta]. All these
-                 values should be in 1/day units.
+            p (dict or array): parameters of the model (alpha, beta). All these
+                 values should be in 1/day units. If a list is used, the order
+                 of parameters is [alpha, beta].
             initial_conds (list): Initial conditions (n_S0, n_I0, n_R0), where:
 
                 - n_S0: Total number of susceptible to the infection
@@ -58,6 +59,9 @@ class SIR(Model):
 
                 which is consistent with the mathematical description
                 of the SIR model.
+
+                If a list is used, the order of initial conditions is
+                [n_S0, n_I0, n_R0]
 
         Returns:
             SIR: reference to self

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -46,16 +46,17 @@ class SIRX(Model):
     """ SIRX model definition """
 
     CSV_ROW = ["Days", "S", "I", "R", "X"]
-    NUM_PARAMS = 5
-    NUM_IC = 4
+    PARAMS = ["alpha", "beta", "kappa_0", "kappa", "inf_over_test"]
+    IC = ["n_S0", "n_I0", "n_R0", "n_X0"]
     NAME = "SIRX"
 
     def set_params(self, p, initial_conds):
         """ Set model parameters.
 
         Args:
-            p (list): parameters of the model [alpha, beta, kappa_0, kappa, inf_over_test].
-                 All these values should be in 1/day units.
+            p (list): parameters of the model (alpha, beta, kappa_0, kappa, inf_over_test).
+                 All these values should be in 1/day units. If a list is used,
+                 the order of parameters is [alpha, beta, kappa_0, kappa, inf_over_test]
             initial_conds (list): Initial conditions (n_S0, n_I0, n_R0, n_X0), where:
 
                 - n_S0: Total number of susceptible to the infection
@@ -74,6 +75,9 @@ class SIRX(Model):
 
                 which is consistent with the mathematical description
                 of the SIR model.
+
+                If a list is used, the order of initial conditions is
+                [n_S0, n_I0, n_R0, n_X0]
 
         Returns:
             SIRX: Reference to self

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -34,3 +34,32 @@ class TestModel:
 
         with pytest.raises(Model.InvalidNumberOfParametersError):
             model.set_params(p, [])
+
+    def test_set_params_with_invalid_dict_params_should_fail(self, model):
+        """Tests that calling set_params with invalid number of dict parameters
+           and initial conditions raises an exception.
+        """
+        model.PARAMS = ["alpha", "beta"]
+        model.IC = ["n_S0", "n_I0", "n_R0"]
+
+        p = {"alpha": -1, "beta": 2}
+        ic = {"n_S0": -1, "n_I0": 2, "n_R0": 3}
+
+        with pytest.raises(Model.InvalidParameterError):
+            model.set_params(p, ic)
+
+    def test_set_params_with_invalid_number_dict_params_should_fail(self, model):
+        """Tests that calling set_params with invalid number of dict parameters
+           and initial conditions raises an exception.
+        """
+        model.PARAMS = ["alpha", "beta"]
+        model.IC = ["n_S0", "n_I0", "n_R0"]
+
+        p = {"alpha": 1, "beta": 2}
+        ic = {"n_S0": 1, "n_I0": 2, "n_R0": 3}
+
+        with pytest.raises(Model.InvalidNumberOfParametersError):
+            model.set_params({}, ic)
+
+        with pytest.raises(Model.InvalidNumberOfParametersError):
+            model.set_params(p, {})

--- a/tests/test_sir.py
+++ b/tests/test_sir.py
@@ -47,3 +47,41 @@ class TestSir:
         )
         # Asert over the difference < 1e-4
         assert abs(n_inf_analytical - n_inf_num) < 1e-4
+
+
+class TestUnittestSir:
+    """ Unittest class for the SIR model """
+
+    @pytest.fixture
+    def model(self):
+        return SIR()
+
+    def test_dict_and_list_params_produce_same_results(self, model):
+        t = 6
+        model.set_params(DEFAULT_PARAMS, EALING_IC)
+        model.solve(t, t + 1)
+        m_list = model.fetch()
+
+        d_params = {"alpha": DEFAULT_PARAMS[0], "beta": DEFAULT_PARAMS[1]}
+        d_ic = {"n_S0": EALING_IC[0], "n_I0": EALING_IC[1], "n_R0": EALING_IC[2]}
+
+        model.set_params(d_params, d_ic)
+        model.solve(t, t + 1)
+        m_dict = model.fetch()
+
+        assert np.array_equal(m_list, m_dict)
+
+    def test_missing_dict_param_should_raise(self, model):
+        d_params = {"alpha": DEFAULT_PARAMS[0], "beta": DEFAULT_PARAMS[1]}
+        d_ic = {"n_S0": EALING_IC[0], "n_I0": EALING_IC[1], "n_R0": EALING_IC[2]}
+
+        bad_params = {"kappa": DEFAULT_PARAMS[0], "beta": DEFAULT_PARAMS[1]}
+        bad_ic = {"n_X0": EALING_IC[0], "n_I0": EALING_IC[1], "n_R0": EALING_IC[2]}
+
+        model.set_params(d_params, d_ic)
+
+        with pytest.raises(SIR.InvalidNumberOfParametersError):
+            model.set_params(d_params, bad_ic)
+
+        with pytest.raises(SIR.InvalidNumberOfParametersError):
+            model.set_params(bad_params, d_ic)


### PR DESCRIPTION
## Contribution description

This PR adds modifies the `set_params` function to accept dictionaries and lists.

This is a showcase of a non breaking API change, since it's still possible to use the old method (ordered lists).
However, I added a deprecation note that the list will be removed soon to support only dicts.

I also added some new tests for ensuring this change is safe and adopted the documentation.

As expected, this change shouldn't break any existing application.

## Test procedure

If the proposed tests make sense, simply run `pipenv run test`.
