### PR TITLE
ci: block merges when PRs are titled/labeled with 'WIP' or 'blocked'

### DIFF
--- a/.github/workflows/wip_blocker.yml
+++ b/.github/workflows/wip_blocker.yml
@@ -1,0 +1,16 @@
+name: WIP blocker
+
+on:
+  pull_request:
+    branches: [master, develop]
+    types: [labeled, unlabeled]
+
+jobs:
+  check_wip:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block merging if PR is labeled/titled with "WIP" or "blocked"
+        uses: ParanoidBeing/action-wip-blocker@v0.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BLOCK_LIST: "WIP|blocked"


### PR DESCRIPTION
This PR adds a GitHub action that runs whenever a PR pointing to `master` or `develop` (inexistent for the time being) is (un)labaled. When it runs, it checks that there is no "WIP" nor "blocked" string in neither the title of the PR, nor its labels.

I think it will only run once this has been merged to master.