### PR TITLE
feat: introduce `set_parametes` and `set_initial_conds` functions

### DIFF
--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -65,7 +65,7 @@ class Model:
 
         Note:
             Support for list of params and initial conditions will be deprecated
-            soon.
+            in future releases.
 
         Returns:
             Model: Reference to self

--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -58,10 +58,10 @@ class Model:
         """ Set model parameters.
         Args:
             p (dict or list): parameters of the model. The parameters units are 1/day,
-                      and should be >= 0.
+                and should be >= 0.
             initial_conds (dict or list): Initial conditions, in total number of individuals.
-            For instance, S0 = n_S0/population, where n_S0 is the number of subjects
-            who are susceptible to the disease.
+                For instance, S0 = n_S0/population, where n_S0 is the number of subjects
+                who are susceptible to the disease.
 
         Note:
             Support for list of params and initial conditions will be deprecated
@@ -74,10 +74,10 @@ class Model:
         params = self.PARAMS
         ic = self.IC
 
-        if type(p) is dict:
+        if isinstance(p, dict):
             p = [p[d] for d in params if d in p.keys()]
 
-        if type(initial_conds) is dict:
+        if isinstance(initial_conds, dict):
             initial_conds = [initial_conds[d] for d in ic if d in initial_conds.keys()]
 
         num_params = len(params)
@@ -207,3 +207,11 @@ class Model:
     def _update_ic(self):
         """ updates initial conditions if necessary """
         return self
+
+
+def _validate_params(arr, num_params):
+    if np.isnan(arr).any() or len(arr) != num_params:
+        raise Model.InvalidNumberOfParametersError
+
+    if sum(arr < 0) > 0:
+        raise Model.InvalidParameterError

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -67,6 +67,10 @@ class SIR(Model):
                 If a list is used, the order of initial conditions is
                 [n_S0, n_I0, n_R0]
 
+        Deprecated:
+            This function is deprecated and will be removed soon.
+            Please use :py:func:`set_parameters` and :py:func:`set_initial_conds`
+
         Returns:
             SIR: reference to self
         """

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -1,5 +1,9 @@
 """Contains class and ODE system of SIR model"""
-from .model import Model
+import numpy as np
+from .model import Model, _validate_params
+
+SIR_NUM_PARAMS = 2
+SIR_NUM_IC = 3
 
 
 def sir(w, t, p):
@@ -73,6 +77,67 @@ class SIR(Model):
 
     def _update_ic(self):
         """Updates initial conditions if necessary"""
+        return self
+
+    def set_parameters(self, array=None, alpha=None, beta=None):
+        """ Set SIR parameters
+
+        Args:
+            array (list): list of parameters of the model ([alpha, beta])
+                If set, all other arguments are ignored.
+                All these values should be in 1/day units.
+            alpha (float): Value of `alpha` in 1/day unit.
+            beta (float): Value of `beta` in 1/day unit.
+
+        Returns:
+            SIR: Reference to self
+        """
+        self.fit_input = 2  # By default, fit against infected
+        if array:
+            arr = np.array(array, dtype=float)
+        else:
+            arr = np.array([alpha, beta], dtype=float)
+
+        _validate_params(arr, SIR_NUM_PARAMS)
+
+        self.p = arr
+        return self
+
+    def set_initial_conds(self, array=None, n_S0=None, n_I0=None, n_R0=None):
+        """ Set SIR initial conditions
+
+        Args:
+            array (list): List of initial conditions [n_S0, n_I0, n_R0].
+                If set, all other arguments are ignored.
+
+                - n_S0: Total number of susceptible to the infection
+                - n_I0: Total number of infected
+                - n_R0: Total number of recovered
+
+                Note: n_S0 + n_I0 + n_R0 = Population
+
+        Note:
+            Internally, the model initial conditions are the ratios
+
+            - S0 = n_S0/Population
+            - I0 = n_I0/Population
+            - R0 = n_R0/Population
+
+            which is consistent with the mathematical description
+            of the SIR model.
+
+        Returns:
+            SIR: Reference to self
+        """
+        if array:
+            arr = np.array(array, dtype=float)
+        else:
+            arr = np.array([n_S0, n_I0, n_R0], dtype=float)
+
+        _validate_params(arr, SIR_NUM_IC)
+
+        self.pop = np.sum(arr)
+        self.w0 = arr / self.pop
         return self
 
     @property

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -119,6 +119,10 @@ class SIRX(Model):
                 If a list is used, the order of initial conditions is
                 [n_S0, n_I0, n_R0, n_X0]
 
+        Deprecated:
+            This function is deprecated and will be removed soon.
+            Please use :py:func:`set_parameters` and :py:func:`set_initial_conds`
+
         Returns:
             SIRX: Reference to self
         """


### PR DESCRIPTION
## Contribution description

This PR introduces 2 new functions for setting model parameters and initial conditions (see https://github.com/open-sir/open-sir/pull/61#issuecomment-614268738)

The old `set_params` function is still available, but added a deprecation note. We should migrate all examples to these new functions.

I also added some tests.

## Testing procedure

`pipenv run doc` and `pipenv run test`

## Related issues/PRs
Depends on #61 