### PR TITLE
test(sirx): create sir-x tests

### DIFF
--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -85,7 +85,7 @@ class Model:
 
         try:
             for param in p:
-                assert param > 0
+                assert param >= 0
         except:
             raise self.InvalidParameterError()
 

--- a/tests/test_sirx.py
+++ b/tests/test_sirx.py
@@ -1,0 +1,127 @@
+# pylint: disable=C0114
+# pylint: disable=C0116
+# pylint: disable=R0124
+# pylint: disable=R0201
+# pylint: disable=C0121
+"Test exponential convergence"
+import numpy as np
+import pytest
+
+from opensir.models import SIRX
+
+DEFAULT_PARAMS = [
+    6.2 / 8,
+    1 / 8,
+    0.05,
+    0.05,
+    5,
+]  # Default parameters from Maier et al (2020)
+GUANGDONG_IC = [104299972, 14, 0, 14]  # Ealing initial conditions
+
+
+class TestSirx:
+    """ Test class for the SIRX model """
+
+    @pytest.fixture
+    def model(self):
+        return SIRX()
+
+    def test_guangdong(self, model):
+        # Check that guangdong 22 days prediction
+        # is accurate with validated test case
+        t = 22  # 23 days
+        model.set_params(DEFAULT_PARAMS, GUANGDONG_IC)
+        model.solve(t, t + 1)
+        infected_end = model.fetch()[-1, 4]
+
+        assert abs(infected_end - 2524.388983) < 0.0001
+
+    def test_expconv(self, model):
+        # Check that the numerical solution of the
+        # reduction from sir-x to sir
+        # converges to I ~ I_0 * exp (alpha-beta)
+        # as (S,t) -> (1,0)
+        # Assume small amount of infected
+        n_i_0 = 1
+        # Assume large population
+        initial_conds = [GUANGDONG_IC[0], n_i_0, 0, n_i_0]
+        # Assume very short time
+        t = 1 / (24 * 3600)
+        # Make kappa, kappa_0 and inf_over_test zero to reduce
+        # the SIR-X to SIR
+        sirx_red_params = [DEFAULT_PARAMS[0], DEFAULT_PARAMS[1], 0, 0, 0]
+        # Calculate analytical and numerical solutions
+        model.set_params(sirx_red_params, initial_conds)
+        model.solve(t, 2)
+        n_inf_num = model.fetch()[-1, 1]
+        n_inf_analytical = n_inf_num * np.exp(
+            (DEFAULT_PARAMS[0] - DEFAULT_PARAMS[1]) * t
+        )
+        perc_error = abs(n_inf_analytical - n_inf_num) / n_inf_num
+        # Assert over the difference < 1e-4
+        assert perc_error < 1e-3
+
+
+class TestUnittestSir:
+    """ Unittest class for the SIRX model """
+
+    @pytest.fixture
+    def model(self):
+        return SIRX()
+
+    def test_dict_and_list_params_produce_same_results(self, model):
+        t = 6
+        model.set_params(DEFAULT_PARAMS, GUANGDONG_IC)
+        model.solve(t, t + 1)
+        sol_list = model.fetch()
+
+        d_params = {
+            "alpha": DEFAULT_PARAMS[0],
+            "beta": DEFAULT_PARAMS[1],
+            "kappa_0": DEFAULT_PARAMS[2],
+            "kappa": DEFAULT_PARAMS[3],
+            "inf_over_test": DEFAULT_PARAMS[4],
+        }
+        d_ic = {
+            "n_S0": GUANGDONG_IC[0],
+            "n_I0": GUANGDONG_IC[1],
+            "n_R0": GUANGDONG_IC[2],
+            "n_X0": GUANGDONG_IC[3],
+        }
+
+        model.set_params(d_params, d_ic)
+        model.solve(t, t + 1)
+        sol_dict = model.fetch()
+
+        assert np.array_equal(sol_list, sol_dict)
+
+    def test_missing_dict_param_should_raise(self, model):
+        d_params = {
+            "alpha": DEFAULT_PARAMS[0],
+            "beta": DEFAULT_PARAMS[1],
+            "kappa_0": DEFAULT_PARAMS[2],
+            "kappa": DEFAULT_PARAMS[3],
+            "inf_over_test": DEFAULT_PARAMS[4],
+        }
+        d_ic = {
+            "n_S0": GUANGDONG_IC[0],
+            "n_I0": GUANGDONG_IC[1],
+            "n_R0": GUANGDONG_IC[2],
+            "n_X0": GUANGDONG_IC[3],
+        }
+
+        bad_params = {"alpha": DEFAULT_PARAMS[0], "beta": DEFAULT_PARAMS[1]}
+        # Typical error trying to initialize SIR-X with SIR parameters
+        bad_ic = {
+            "n_S0": GUANGDONG_IC[0],
+            "n_I0": GUANGDONG_IC[1],
+            "n_R0": GUANGDONG_IC[2],
+        }
+
+        model.set_params(d_params, d_ic)
+
+        with pytest.raises(SIRX.InvalidNumberOfParametersError):
+            model.set_params(d_params, bad_ic)
+
+        with pytest.raises(SIRX.InvalidNumberOfParametersError):
+            model.set_params(bad_params, d_ic)


### PR DESCRIPTION
In response to #64, I begin writing SIR-X tests from the sir template that @jia200x created.

As SIR-X is mathematically more complex, the logical tests will be adapted but new mathematical tests will be implemented.

I will not test any .fit() functionality here as that will be a separate PR dealing with a potentially much more difficult issue.