### PR TITLE
 test(model): create fit tests and improve fit validation

### DIFF
--- a/doc/tutorials/SIR-X.ipynb
+++ b/doc/tutorials/SIR-X.ipynb
@@ -355,7 +355,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.4"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/doc/tutorials/SIR.ipynb
+++ b/doc/tutorials/SIR.ipynb
@@ -128,7 +128,8 @@
    "outputs": [],
    "source": [
     "# Use Ealing as an example to determine model initial conditions\n",
-    "Ealing_data = [8, 18, 20, 18, 21, 42, 53, 54, 80, 97, 106, 123, 136, 165, 209, 241] # N_of infected\n",
+    "# Input data must be np.array\n",
+    "Ealing_data = np.array([8, 18, 20, 28, 31, 42, 53, 54, 80, 97, 106, 123, 136, 165, 209, 241]) # N_of infected\n",
     "\n",
     "P_Ealing = 342000 # Ealing population ONS 2018 mid year\n",
     "I_Ealing = 8      # Infected people at 14/03/2020\n",
@@ -266,6 +267,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ealing_data"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -286,9 +296,9 @@
     "# Convert into seconds\n",
     "tf_long = long_term_days-1\n",
     "sol_long = my_SIR_fitted.solve(tf_long, long_term_days).fetch()\n",
-    "N_S_long = sol_long[:,1]*P_Ealing\n",
-    "N_I_long = sol_long[:,2]*P_Ealing\n",
-    "N_R_long = sol_long[:,3]*P_Ealing"
+    "N_S_long = sol_long[:,1]\n",
+    "N_I_long = sol_long[:,2]\n",
+    "N_R_long = sol_long[:,3]"
    ]
   },
   {
@@ -436,7 +446,7 @@
    "source": [
     "P_UK = 67886011\n",
     "# Data up to 28th of March\n",
-    "I_UK= [3269, 3983, 5018, 5683, 6650, 8077, 9529, 11658, 14543, 17089]\n",
+    "I_UK= np.array([3269, 3983, 5018, 5683, 6650, 8077, 9529, 11658, 14543, 17089])\n",
     "n_days = len(I_UK) # Final day\n",
     "t_d = np.linspace(0,n_days-1,n_days)\n",
     "\n",
@@ -476,6 +486,15 @@
    "source": [
     "MSE = sum(np.sqrt((I_opt-I_UK)**2))/len(I_UK)        \n",
     "print(\"Mean squared error on the model in the train dataset %.2f\" % MSE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The mean squared error calculated above indicates the average error difference between the model fitting and the train data. It is a measure of wellness of fit, but it doesn't provide information about how accurately the model predicts the number of infected.\n",
+    "\n",
+    "The error in the future predictions can be estimating through confidence intervals."
    ]
   },
   {
@@ -645,7 +664,7 @@
     "plt.ylabel(\"Rolling $R_0$\")\n",
     "plt.title(\"Block bootstrapping change in $R_0$\")\n",
     "plt.subplot(1,2,2)\n",
-    "plt.plot(MSE_list,'bo')\n",
+    "plt.plot(t_d[(2+n_lags):], MSE_list,'bo')\n",
     "plt.xlabel(\"Days used in the block to fit parameters\")\n",
     "plt.ylabel(\"Mean squared error in number of infected\")\n",
     "plt.title(\"Block bootstrapping change in MSE\")\n",
@@ -653,11 +672,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the mean squared error is provided in absolute terms. However, the number of infected cases is increasing with time. \n",
+    "\n",
+    "The percentage error of the predictions can be calculated directly from the mean squared error. \n",
+    "\n",
+    "$$\\epsilon(t) = \\frac{\\mathrm{MSE}(t)}{I(t)}$$\n",
+    "\n",
+    "For example, in the last entry of I_UK, they were 17089 infected, while the MSE was 666.45. Then, the percentage deviation would be:\n",
+    "\n",
+    "$$ \\epsilon(10) = \\frac{666.45}{17089} = 3.9\\% $$ \n",
+    "\n",
+    "However, this takes model prediction over the accumulated number of cases. Another way to quantify the deviation of the model predictions is to calculate the percentage error over the new infected cases:\n",
+    "\n",
+    "$$\\epsilon_{\\mathrm{new}}(t) = \\frac{\\mathrm{MSE}(t)}{I(t)-I(t-1)}$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If this metric is used, the error naturally will be much higher:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "e_new = MSE_list[-1]/(I_UK[-1]-I_UK[-2])\n",
+    "print(\"The percentage error of the SIR model over the last day reported cases is %.1f%%\" % (100*e_new))"
+   ]
   }
  ],
  "metadata": {
@@ -677,7 +725,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.4"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-self-use
 "Test exponential convergence"
 import pytest
+import numpy as np
 from opensir.models import Model
 
 
@@ -63,3 +64,56 @@ class TestModel:
 
         with pytest.raises(Model.InvalidNumberOfParametersError):
             model.set_params(p, {})
+
+    def test_fit_parameter_consistency(self, model):
+        """ Tests that running the fit function with inconsistent inputs
+        between n_i_obs and t_obs, or fit_index and self.p, raise error"""
+
+        t_obs = np.array([0, 1, 2, 3, 4])
+        n_i_obs = np.array([0, 10, 20])
+        pop = 1000
+        # Test with a fit_index for an unrealistic
+        # number of parameters
+        model.p = [1, 2]
+        fit_index = [True, False, False]
+
+        # Test inconsistent dimensions of t_obs and n_i_obs
+        with pytest.raises(Model.InconsistentDimensionsError):
+            model.fit(t_obs, n_i_obs, pop)
+        # Testinconsistent dimnesions between fit_index and self.p
+        with pytest.raises(Model.InconsistentDimensionsError):
+            model.fit(t_obs[:3], n_i_obs, pop, fit_index)
+
+    def test_input_validity(self, model):
+        """ Test that providing negative times, negative number of
+        infections or non monotonic increasing times or number of
+        infections outputs an error"""
+
+        t_obs = np.array([0, 1, 2, 3])
+        t_neg = np.array([-4, -3, -2, -1])
+        t_dec = np.array([0, 1, 2, 1])
+        t_list = [0, 1, 2, 3]
+
+        n_obs = np.array([0, 10, 20, 35])
+        n_neg = np.array([-35, 0, 10, 20])
+        n_list = [0, 10, 20, 35]
+
+        model.p = [2, 1]
+
+        pop = 1000
+
+        # Check for negative times
+        with pytest.raises(Model.InvalidParameterError):
+            model.fit(t_neg, n_obs, pop)
+        # Check for non monotonically increasing time
+        with pytest.raises(Model.InvalidParameterError):
+            model.fit(t_dec, n_obs, pop)
+        # Check for negative number of observed infections
+        with pytest.raises(Model.InvalidParameterError):
+            model.fit(t_obs, n_neg, pop)
+        # Check that passing a list of times raises error
+        with pytest.raises(Model.InvalidParameterError):
+            model.fit(t_list, n_obs, pop)
+        # Check that passing a list of n_obs raises an error
+        with pytest.raises(Model.InvalidParameterError):
+            model.fit(t_obs, n_list, pop)


### PR DESCRIPTION
Two new sets of tests were included for the model.fit function.

1. InconsistentDimensionError: raise an error whenever the
dimensions of input fitting data are not consistent. Can be
overloaded for other post regression functionalities.

2. InvalidInputsForFittingError: raised when either the
list of observed times or the list of number of infections 
are negative or non increasing.

Some piggybacking for casting lists to arrays for fit
inputs is also included, as this enables more efficient
exception testing.

These are non-breaking changes as they didn't affect the Jupyter notebooks examples.

If #63 gets merged before, I have no problem on updating some of the tests so
the mock model can be setup with the set_parameters and set_ic's.