### PR TITLE
ci: cache Docker image builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,8 @@ jobs:
     steps:
       - checkout
       - docker/build:
-          image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+          image: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
+          cache_from: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
 
 workflows:
   version: 2
@@ -118,5 +119,6 @@ workflows:
             branches:
               only: master
           image: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
+          cache_from: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
           tag: latest #TODO: version this somehow, defaults to $CIRCLE_SHA1
           use-docker-credentials-store: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,8 @@ jobs:
     steps:
       - checkout
       - docker/build:
-          image: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
-          cache_from: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
+          image: opensir/$CIRCLE_PROJECT_REPONAME
+          cache_from: opensir/$CIRCLE_PROJECT_REPONAME
 
 workflows:
   version: 2
@@ -118,7 +118,7 @@ workflows:
           filters:
             branches:
               only: master
-          image: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
-          cache_from: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
+          image: opensir/$CIRCLE_PROJECT_REPONAME
+          cache_from: opensir/$CIRCLE_PROJECT_REPONAME
           tag: latest #TODO: version this somehow, defaults to $CIRCLE_SHA1
           use-docker-credentials-store: true


### PR DESCRIPTION
This PR makes use of Docker image caching when building the Docker image. It makes the CI take 2 minutes less (and it was by far the longest job in the CI).

Basically, instead of trying to build the image from scratch every time, it downloads an already existing version of the same image, and tries to use cache from there.