### PR TITLE
test: post regression tests

### DIFF
--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -41,6 +41,7 @@ class Model(ConfidenceIntervalsMixin):
         self.w0 = None
         self.fit_input = None
         self.fit_attr = None  # Dict set after the first call of fit
+        self.is_fitted = False  # True after calling model.fit() function successfully
 
     class InvalidParameterError(Exception):
         """Raised when an initial parameter of a value is not correct"""
@@ -257,6 +258,7 @@ class Model(ConfidenceIntervalsMixin):
         )
         self.p[self.fit_attr["fit_index"]] = par_opt
         self.fit_attr["pcov"] = pcov  # This also flags that the model was fitted
+        self.is_fitted = True
         return self
 
     def _update_ic(self):

--- a/opensir/models/post_regression.py
+++ b/opensir/models/post_regression.py
@@ -71,11 +71,11 @@ class PredictionResults:
 
         plt.legend(
             [
-                "-2$\sigma$ 95% IC",  # pylint: disable=W1401
-                "-$\sigma$ 66% IC",  # pylint: disable=W1401
+                "-2$\\sigma$ 95% IC",  # pylint: disable=W1401
+                "-$\\sigma$ 66% IC",  # pylint: disable=W1401
                 "Prediction",
-                "+$\sigma$ 66% IC",  # pylint: disable=W1401
-                "+2$\sigma$ 95% IC",  # pylint: disable=W1401
+                "+$\\sigma$ 66% IC",  # pylint: disable=W1401
+                "+2$\\sigma$ 95% IC",  # pylint: disable=W1401
             ],
             fontsize=12,
         )
@@ -197,18 +197,6 @@ class ConfidenceIntervalsMixin:
         """
 
         self.is_initialized()
-
-        # If no options provided, use default confidence interval of 95%
-        if options is None:
-            options = {"alpha": 0.95, "n_iter": 1000, "r0_ci": True}
-        else:
-            opt_keys = ["alpha", "n_iter", "r0_ci"]
-            for key in opt_keys:
-                if key not in options:
-                    raise self.InvalidParameterError(
-                        "options dictionary doesn't include all keys"
-                    )
-
         p0 = self.p
 
         p_bt = []
@@ -251,7 +239,7 @@ class ConfidenceIntervalsMixin:
         time (t+1) is not independent from the value of the states in the
         time t.
 
-        The model needs to be initialized and fitted prior 
+        The model needs to be initialized and fitted prior
         calling block_cv.
 
         The cross-validation mean squared error can be used to

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -124,13 +124,13 @@ class TestModel:
         are from an model instance that doesn't have initialized
         it parameters or initial conditions"""
 
-        population = 1e6
-        t_obs = np.array([0, 1, 2, 3])
-        n_obs = np.array([2, 4, 7, 10])
-        model.is_fitted = True
+        # model.is_fitted = True
         # Fail if the model is somehow fitted but not initialized
         with pytest.raises(Model.InitializationError):
-            model.ci_bootstrap(t_obs, n_obs, population, options=None)
+            model.ci_bootstrap()
+
+        with pytest.raises(Model.InitializationError):
+            model.block_cv()
 
     def test_postregression_without_regression(self, model):
         """ Set of tests that verify that the model attributes are setted
@@ -140,34 +140,13 @@ class TestModel:
         model.IC = ["n_S0", "n_I0", "n_R0"]
 
         population = 1e6
-        t_obs = np.array([0, 1, 2, 3])
         n_obs = np.array([2, 4, 7, 10])
         p = [1, 2]
         w0 = [population, population - n_obs[0], 0]
         model.set_params(p, w0)
         # Fail if the model has not been fitted
         with pytest.raises(Model.InitializationError):
-            model.ci_bootstrap(t_obs, n_obs, population, options=None)
+            model.ci_bootstrap()
 
-    def test_postregression_invalid_options_dict(self, model):
-        """ Tests that an error is raised if an invalid options
-        dict is passed to postregression """
-        # model.PARAMS = ["alpha", "beta"]
-        # model.IC = ["n_S0", "n_I0", "n_R0"]
-
-        # population = 1e6
-        # t_obs = np.array([0, 1, 2, 3])
-        # n_obs = np.array([2, 4, 7, 10])
-        # p = [1, 2]
-        # w0 = [population, population - n_obs[0], 0]
-        # model.set_params(p, w0)
-        # model.is_fitted = True
-        # bootstrap_options = {'alpha': 0.95, 'n_iter': 100, 'r_ci': True}
-        # blockcv_options = {'lags': 6}
-        # Fail if the model has not been fitted
-        # ! Update this to the verbose parameteric input
-        # with pytest.raises(Model.InvalidParameterError):
-        #     model.ci_bootstrap(t_obs, n_obs, population, bootstrap_options)
-
-        # with pytest.raises(Model.InvalidParameterError):
-        #     model.ci_block_cv(t_obs, n_obs, population, blockcv_options)
+        with pytest.raises(Model.InitializationError):
+            model.block_cv()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -116,3 +116,58 @@ class TestModel:
         # Check that passing a list of n_obs raises an error
         with pytest.raises(Model.InvalidParameterError):
             model.fit(t_obs, n_list, pop)
+
+    ## Post-regression
+    # ci_bootstrap
+    def test_ci_without_model_init(self, model):
+        """ Tests that an error is raised if the ci routines
+        are from an model instance that doesn't have initialized
+        it parameters or initial conditions"""
+
+        population = 1e6
+        t_obs = np.array([0, 1, 2, 3])
+        n_obs = np.array([2, 4, 7, 10])
+        model.is_fitted = True
+        # Fail if the model is somehow fitted but not initialized
+        with pytest.raises(Model.InitializationError):
+            model.ci_bootstrap(t_obs, n_obs, population, options=None)
+
+    def test_postregression_without_regression(self, model):
+        """ Set of tests that verify that the model attributes are setted
+        or fitted before calling postregression routines"""
+
+        model.PARAMS = ["alpha", "beta"]
+        model.IC = ["n_S0", "n_I0", "n_R0"]
+
+        population = 1e6
+        t_obs = np.array([0, 1, 2, 3])
+        n_obs = np.array([2, 4, 7, 10])
+        p = [1, 2]
+        w0 = [population, population - n_obs[0], 0]
+        model.set_params(p, w0)
+        # Fail if the model has not been fitted
+        with pytest.raises(Model.InitializationError):
+            model.ci_bootstrap(t_obs, n_obs, population, options=None)
+
+    def test_postregression_invalid_options_dict(self, model):
+        """ Tests that an error is raised if an invalid options
+        dict is passed to postregression """
+        # model.PARAMS = ["alpha", "beta"]
+        # model.IC = ["n_S0", "n_I0", "n_R0"]
+
+        # population = 1e6
+        # t_obs = np.array([0, 1, 2, 3])
+        # n_obs = np.array([2, 4, 7, 10])
+        # p = [1, 2]
+        # w0 = [population, population - n_obs[0], 0]
+        # model.set_params(p, w0)
+        # model.is_fitted = True
+        # bootstrap_options = {'alpha': 0.95, 'n_iter': 100, 'r_ci': True}
+        # blockcv_options = {'lags': 6}
+        # Fail if the model has not been fitted
+        # ! Update this to the verbose parameteric input
+        # with pytest.raises(Model.InvalidParameterError):
+        #     model.ci_bootstrap(t_obs, n_obs, population, bootstrap_options)
+
+        # with pytest.raises(Model.InvalidParameterError):
+        #     model.ci_block_cv(t_obs, n_obs, population, blockcv_options)


### PR DESCRIPTION
I began the creation of tests for the confidence interval routines.

Note that this branch is branched from the PR #69, so it depends on merging that one.

We could potentially spend our whole life thinking on tests for confidence intervals so I am trying to write the most typical ones, such as providing incorrect inputs, not initializing the model or not fitting the model prior calling confidence intervals.

Still work in progress but some significant progress has been made. I am aware that this will require some rebase and so on.

## Update 13/07/2020

The tests are now adequate to the latest version of `open-sir`!