### PR TITLE
refactor(post_regression): change `option` parameter to explicit kwargs

### DIFF
--- a/doc/tutorials/SIR.ipynb
+++ b/doc/tutorials/SIR.ipynb
@@ -514,7 +514,7 @@
     "# Define bootstrap options\n",
     "options = {\"alpha\":0.95, \"n_iter\":1000, \"r0_ci\":True}\n",
     "# Call bootstrap\n",
-    "par_ci, par_list = SIR_UK.ci_bootstrap(t_d, I_UK, P_UK, options)"
+    "par_ci, par_list = SIR_UK.ci_bootstrap(t_d, I_UK, P_UK, **options)"
    ]
   },
   {
@@ -620,7 +620,7 @@
     "# We previously imported ci_block_cv which provides a better prediction of the mean squared error of the predictions\n",
     "n_lags = 1\n",
     "options={\"lags\":n_lags,\"min_sample\":3}\n",
-    "MSE_avg, MSE_list, p_list = SIR_UK.ci_block_cv(t_d, I_UK, P_UK, options)"
+    "MSE_avg, MSE_list, p_list = SIR_UK.ci_block_cv(t_d, I_UK, P_UK, **options)"
    ]
   },
   {


### PR DESCRIPTION
## Contribution Description

This PR changes the "options" parameter of both ci_xxx functions to explicit keyword arguments.
The rationale behind this is:
- Provide native Python defaults (e.g `ci_r0=True`)
- display a cleaner documentation
- Be able to modify only one default instead of all options at the same time

I also adapted the Jupyter to this change, so the documentation should still render OK.

## Testing procedure

Try building the documentation with `pipenv run doc`. The SIR.ipynb has some routines calling these functions, so it should be enough for now to check that the documentation is equivalent.

## Related PR/Issues
~Depends on #69~