### PR TITLE
fix(readthedocs): fix wrong location of conf.py

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: conf.py
+  configuration: doc/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all


### PR DESCRIPTION
## Contribution Description

This PR fixes the path of `conf.py` in the readthedocs YAML file.
With this change, readthedocs should be able to compile the documentation.

## Testing procedure

I will post a link with the RTD results