### PR TITLE
fix: generalize confidence intervals

### DIFF
--- a/doc/tutorials/SIR-X.ipynb
+++ b/doc/tutorials/SIR-X.ipynb
@@ -11,9 +11,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook exemplifies how Open-SIR can be used to fit the SIR-X model by [Maier and Dirk (2020)](https://science.sciencemag.org/content/early/2020/04/07/science.abb4557.full) to existing data and make predictions. The SIR-X model is an standard generalization of the Susceptible-Infectious-Removed (SIR) model, which includes the influence of exogeneous factors such as policy changes, lockdown of the whole population and quarantine of the infectious individuals.\n",
+    "This notebook exemplifies how Open-SIR can be used to fit the SIR-X model by [Maier and Dirk (2020)](https://science.sciencemag.org/content/early/2020/04/07/science.abb4557.full) to existing data and make predictions. The SIR-X model is a standard generalization of the Susceptible-Infectious-Removed (SIR) model, which includes the influence of exogenous factors such as policy changes, lockdown of the whole population and quarantine of the infectious individuals.\n",
     "\n",
-    "To validate the Open-SIR implementation of the SIR-X model, it will be attempted to reproduce the parameter fitting published in the [suplementary material](https://science.sciencemag.org/cgi/content/full/science.abb4557/DC1) of the original recent article published by [Maier and Dirk (2020)](https://science.sciencemag.org/content/early/2020/04/07/science.abb4557.full). For simplicity, the validation will be performed only for the city of Guangdong, China."
+    "The Open-SIR implementation of the SIR-X model will be validated reproducing the parameter fitting published in the [supplementary material](https://science.sciencemag.org/cgi/content/full/science.abb4557/DC1) of the original article published by [Maier and Brockmann (2020)](https://science.sciencemag.org/content/early/2020/04/07/science.abb4557.full). For simplicity, the validation will be performed only for the city of Guangdong, China."
    ]
   },
   {
@@ -31,7 +31,8 @@
    "source": [
     "# Import packages\n",
     "import pandas as pd\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np"
    ]
   },
   {
@@ -66,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is observed that the column \"Province/States\" contains the name of the cities, and since the forth column a time series stamp (or index) is provided to record daily data of reported cases. Additionally, there are many days without recorded data for a number of chinese cities. This won't be an issue for parameter fitting as **Open-SIR** doesn't require uniform spacement of the observed data."
+    "It is observed that the column \"Province/States\" contains the name of the cities, and since the forth column a time series stamp (or index) is provided to record daily data of reported cases. Additionally, there are many days without recorded data for a number of chinese cities. This won't be an issue for parameter fitting as Open-SIR doesn't require uniform spacement of the observed data."
    ]
   },
   {
@@ -261,7 +262,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g_sirx.p"
+    "plt.plot?"
    ]
   },
   {
@@ -270,11 +271,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.plot(t_sirx, inf_sirx)\n",
-    "plt.plot(t_SIR, I_SIR)\n",
+    "plt.figure(figsize=[6,6])\n",
+    "ax = plt.axes()\n",
+    "plt.plot(t_sirx, inf_sirx, 'b-', linewidth=2)\n",
+    "plt.plot(t_SIR, I_SIR,'g-', linewidth=2)\n",
     "plt.plot(t_days, nX, 'ro')\n",
-    "plt.legend([\"SIR-X\", \"SIR\", \"observed\"])\n",
-    "plt.title(\"Guangdong\")\n",
+    "plt.legend([\"SIR-X model fit\", \"SIR model fit\", \"Number of reported cases\"], fontsize=13)\n",
+    "plt.title(\"SARS-CoV-2 evolution in Guangdong, China\", size=15)\n",
+    "plt.xlabel('Days', fontsize=14)\n",
+    "plt.ylabel('COVID-19 confirmed cases', fontsize=14)\n",
+    "ax.grid(True)\n",
+    "ax.tick_params(axis='both', which='major', labelsize=14)\n",
     "plt.show()"
    ]
   },
@@ -284,13 +291,13 @@
    "source": [
     "After fitting the parameters, the effective infectious period $T_{I,eff}$ and the effective reproduction rate $R_{0,eff}$ can be obtained from the model properties\n",
     "\n",
-    "$$ T_{I,eff} = (\\beta + \\kappa + \\kappa_0)^{-1} $$\n",
-    "$$ R_{0,eff} = \\alpha T_{I,eff}$$\n",
+    "$$T_{I,eff} = (\\beta + \\kappa + \\kappa_0)^{-1}$$\n",
+    "$$R_{0,eff} = \\alpha T_{I,eff}$$\n",
     "\n",
     "Aditionally, the Public containment leverage $P$ and the quarantine probability $Q$ can be calculated through:\n",
     "\n",
-    "$$ P = \\frac{\\kappa_0}{\\kappa_0 + \\kappa} $$\n",
-    "$$ Q = \\frac{\\kappa_0 + \\kappa}{\\beta + \\kappa_0 + \\kappa} $$"
+    "$$P = \\frac{\\kappa_0}{\\kappa_0 + \\kappa}$$\n",
+    "$$Q = \\frac{\\kappa_0 + \\kappa}{\\beta + \\kappa_0 + \\kappa}$$"
    ]
   },
   {
@@ -309,6 +316,191 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Calculation of predictive confidence intervals\n",
+    "\n",
+    "The confidence intervals on the predictions of the SIR-X model can be calculated using a block cross validation. This technique is widely used in Time Series Analysis. In the open-sir API, the function `model.ci_block_cv` calculates the average mean squared error of the predictions, a list of the rolling mean squared errors and the list of parameters which shows how much each parameter changes taking different number of days for making predictions.\n",
+    "\n",
+    "The three first parameters are the same as the fit function, while the last two parameters are the `lags` and the `min_sample`. The `lags` parameter indicates how many periods in the future will be forecasted in order to calculate the mean squared error of the model prediction. The `min_sample` parameter indicates the initial number of observations and days that will be taken to perform the block cross validation.\n",
+    "\n",
+    "In the following example,`model.ci_block_cv` is used to estimate the average mean squared error of *1-day* predictions taking *3* observations as the starting point of the cross validation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate confidence intervals\n",
+    "mse_avg, mse_list, p_list = g_sirx.ci_block_cv(t_days, nX, N, lags = 1, min_sample=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Amazing! let's print the average mean squared error (MSE) for one-day predictions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"One day estimation of the mean squared error of SIR-X fitted to Guangdong Data = %.0f\" % mse_avg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If it is assumed that the residuals distribute normally, then a good estimation of a 95% confidence interval on the one-day prediction of the number of confirmed cases is \n",
+    "\n",
+    "$$\\sigma \\sim \\mathrm{MSE} \\rightarrow n_{X,{t+1}} \\sim \\hat{n}_{X,{t+1}} \\pm 2 \\sigma$$ "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Where $n_{X,{t+1}}$ is the real number of confirmed cases in the next day, and $\\hat{n}_{X,{t+1}}$ is the estimation using the SIR-X model using cross validation. We use solve to make a 1-day prediction and append the 95% confidence interval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "error",
+     "ename": "NameError",
+     "evalue": "name 'g_sirx' is not defined",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-1-0b09b1c0fb50>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[1;31m# Predict\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 2\u001b[1;33m \u001b[0mg_sirx\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msolve\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mt_days\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;33m-\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m+\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m\u001b[0mt_days\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;33m-\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m+\u001b[0m\u001b[1;36m2\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      3\u001b[0m \u001b[0mn_X_tplusone\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mg_sirx\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfetch\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;33m-\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m4\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Estimation of n_X_{t+1} = %.0f +- %.0f \"\u001b[0m \u001b[1;33m%\u001b[0m \u001b[1;33m(\u001b[0m\u001b[0mn_X_tplusone\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;36m2\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mmse_avg\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mNameError\u001b[0m: name 'g_sirx' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "# Predict\n",
+    "g_sirx.solve(t_days[-1]+1,t_days[-1]+2)\n",
+    "n_X_tplusone = g_sirx.fetch()[-1,4]\n",
+    "print(\"Estimation of n_X_{t+1} = %.0f +- %.0f \" % (n_X_tplusone, 2*mse_avg) )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But the model seems to fit far better than this estimation. Fortunately, it is possible to explore the residuals of the block cross validation through the mse_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "output_type": "error",
+     "ename": "NameError",
+     "evalue": "name 'plt' is not defined",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-2-48e168c99f9a>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mplt\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfigure\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mfigsize\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;36m4\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m4\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      2\u001b[0m \u001b[0mplt\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mplot\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mmse_list\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;34m'ro'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      3\u001b[0m \u001b[0mplt\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mxlabel\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'Number of days used to predict the next day'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m \u001b[0mplt\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mylabel\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'MSE'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      5\u001b[0m \u001b[0mplt\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mshow\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mNameError\u001b[0m: name 'plt' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=[4,4])\n",
+    "plt.plot(mse_list,'ro')\n",
+    "plt.xlabel('Number of days used to predict the next day')\n",
+    "plt.ylabel('MSE')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is an outlier on day 1, as this is when the missing date starts. A more reliable approach would be to take the last 8 values of the mean squared error to calculate a new average assuming that there will be no more missing data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "after_missing_values_MSE = np.mean(mse_list[-8:])\n",
+    "print(\"New MSE = %.1f\" % after_missing_values_MSE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Which provides a value that is more aligned with the spread observed in the previous plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Predict\n",
+    "g_sirx.solve(t_days[-1]+1,t_days[-1]+2)\n",
+    "n_X_tplusone = g_sirx.fetch()[-1,4]\n",
+    "print(\"Estimation of n_X_{t+1} = %.0f +- %.0f \" % (n_X_tplusone, 2*after_missing_values_MSE) )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Variation of fitted parameters\n",
+    "\n",
+    "Finally, it is possible to observe how the model parameters change as more days and number of confirmed cases are introduced in the block cross validation. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Transform parameter list into a DataFrame\n",
+    "par_block_cv = pd.DataFrame(p_list)\n",
+    "# Rename dataframe columns based on SIR-X parameter names\n",
+    "par_block_cv.columns = g_sirx.PARAMS\n",
+    "# Add the day. Note that we take the days from min_sample until the end of the array, as days\n",
+    "# 0,1,2 are used for the first sampling in the block cross-validation\n",
+    "par_block_cv['Day'] = t_days[3:]\n",
+    "# Explore formatted dataframe for parametric analysis\n",
+    "par_block_cv.head(len(p_list))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is clear to observe that after day 5 all parameters except kappa begin to converge. Therefore, care must be taken when performing inference over the parameter kappa."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Long term prediction\n",
     "Now we can use the model to predict when the peak will occur and what will be the maximum number of infected"
    ]
   },
@@ -319,13 +511,16 @@
    "outputs": [],
    "source": [
     "# Predict\n",
+    "plt.figure(figsize=[6,6])\n",
+    "ax = plt.axes()\n",
+    "ax.tick_params(axis=\"both\", which=\"major\", labelsize= 14 )\n",
     "g_sirx.solve(40,41)\n",
     "# Plot\n",
-    "plt.plot(g_sirx.fetch()[:,4]) # X(t)\n",
-    "plt.plot(g_sirx.fetch()[:,2]) # I(t)\n",
-    "plt.xlabel('Day')\n",
-    "plt.ylabel('Number of people')\n",
-    "plt.legend([\"X(t): tested and quarantined\",\"I(t) = infected\"])\n",
+    "plt.plot(g_sirx.fetch()[:,4], 'b-', linewidth=2) # X(t)\n",
+    "plt.plot(g_sirx.fetch()[:,2], 'b--', linewidth=2) # I(t)\n",
+    "plt.xlabel('Day', size=14)\n",
+    "plt.ylabel('Number of people', size=14)\n",
+    "plt.legend([\"X(t): Confirmed\",\"I(t) = Infected\"], fontsize=13)\n",
     "plt.title(city_name)\n",
     "plt.show()"
    ]
@@ -334,7 +529,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The model was trained with a limited amount of data. It is clear to observe that since the measures took place in Guangdong, at least 6 weels pf quarantine were necessary to control the pandemics. Note that a limitation of this model is that it predicts an equilibrium where the number of infected is 0 after a short time. In reality, this amount will decrease to a small number. What we see in the TV is the X(t) curve. After the curve \"flattens\", it is necessary to keep quarantine for more time and perform effective contact tracing of the remainder of the infected people who hasn't recovered yet."
+    "The model was trained with a limited amount of data. It is clear to observe that since the measures took place in Guangdong, at least 6 weeks of quarantine were necessary to control the pandemics. Note that a limitation of this model is that it predicts an equilibrium where the number of infected, denoted by the yellow line in the figure above, is 0 after a short time. In reality, this amount will decrease to a small number.\n",
+    "\n",
+    "After the peak of infections is reached, it is necessary to keep the quarantine and effective contact tracing for at least 30 days more."
    ]
   }
  ],
@@ -355,7 +552,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.4-final"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/doc/tutorials/SIR.ipynb
+++ b/doc/tutorials/SIR.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "Where `$ \\beta $` is the percentage of the infected population that is removed from the transmission process per day.\n",
     "\n",
-    "In early stages of the infection, the number of infected people is much lower than the susceptible populations. Hence, `$S \\approx 1$` making `$dI/dt$` linear and the system has the analytical solution `$I(t) = I_0 \\exp (\\alpha - \\beta)t$`.\n",
+    "In early stages of the infection, the number of infected people is much lower than the susceptible populations. Hence, $S \\approx 1$ making $dI/dt$ linear and the system has the analytical solution $I(t) = I_0 \\exp (\\alpha - \\beta)t$.\n",
     "\n"
    ]
   },
@@ -70,8 +70,8 @@
     "\n",
     "Following this approach, the SIR model can be implemented as it follows:\n",
     "\n",
-    "$$ \\vec{w} = [S,I,R]$$\n",
-    "$$ \\vec{p} = [\\alpha, \\beta] $$\n",
+    "$$\\vec{w} = [S,I,R]$$\n",
+    "$$\\vec{p} = [\\alpha, \\beta] $$\n",
     "\n",
     "And $t$ enters directly. The function return will be the list of ODEs.\n",
     "\n",
@@ -618,9 +618,8 @@
    "outputs": [],
    "source": [
     "# We previously imported ci_block_cv which provides a better prediction of the mean squared error of the predictions\n",
-    "n_lags = 1\n",
-    "options={\"lags\":n_lags,\"min_sample\":3}\n",
-    "MSE_avg, MSE_list, p_list = SIR_UK.ci_block_cv(t_d, I_UK, P_UK, **options)"
+    "n_lags=1\n",
+    "MSE_avg, MSE_list, p_list = SIR_UK.ci_block_cv(t_d, I_UK, P_UK, lags=n_lags, min_sample=3)\n"
    ]
   },
   {
@@ -674,6 +673,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"MSE_lastday = %.2f\" % MSE_list[-1])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -685,7 +693,7 @@
     "\n",
     "For example, in the last entry of I_UK, they were 17089 infected, while the MSE was 666.45. Then, the percentage deviation would be:\n",
     "\n",
-    "$$ \\epsilon(10) = \\frac{666.45}{17089} = 3.9\\% $$ \n",
+    "$$\\epsilon(10) = \\frac{22.76}{17089} = 0.13\\%$$ \n",
     "\n",
     "However, this takes model prediction over the accumulated number of cases. Another way to quantify the deviation of the model predictions is to calculate the percentage error over the new infected cases:\n",
     "\n",
@@ -696,7 +704,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If this metric is used, the error naturally will be much higher:"
+    "If this metric is used, the error naturally will be higher. "
    ]
   },
   {
@@ -707,6 +715,23 @@
    "source": [
     "e_new = MSE_list[-1]/(I_UK[-1]-I_UK[-2])\n",
     "print(\"The percentage error of the SIR model over the last day reported cases is %.1f%%\" % (100*e_new))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It must be noted that in the last day studied, the error is extremely low owing to an exceptionally good agreement on the last point of the data. Hence, a better estimate of the error in the predictions is to take the average percentage error on the cross validation subset, which considers from day 3 onwards."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eps_avg = np.mean(MSE_list/I_UK[-7:])*100\n",
+    "print(\"The average percentage deviation on the number of infected is %.1f%%\" % eps_avg)"
    ]
   }
  ],
@@ -727,7 +752,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.4-final"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/doc/tutorials/SIR.ipynb
+++ b/doc/tutorials/SIR.ipynb
@@ -557,7 +557,7 @@
    "outputs": [],
    "source": [
     "# Build numerical solution\n",
-    "I_opt = SIR_UK.solve(n_days-1, n_days).fetch()[:,2]\n",
+    "# I_opt = SIR_UK.solve(n_days-1, n_days).fetch()[:,2]\n",
     "beta_0 = SIR_UK.p[1]\n",
     "SIR_minus = SIR().set_params([alpha_min, beta_0],n0_UK)\n",
     "SIR_plus = SIR().set_params([alpha_max, beta_0],n0_UK)\n",
@@ -652,7 +652,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "r0_roll = p_list[:,0]/p_list[:,1]\n",

--- a/opensir/models/post_regression.py
+++ b/opensir/models/post_regression.py
@@ -34,15 +34,9 @@ def _percentile_to_ci(alpha, p_bt):
 class ConfidenceIntervalsMixin:
     """ Mixin with confidence interval definitions """
 
-    def ci_bootstrap(
-        self,
-        t_obs,
-        n_i_obs,
-        population,
-        alpha=0.95,
-        n_iter=1000,
-        r0_ci=True,  # pylint: disable=C0330
-    ):
+    def ci_bootstrap(  # pylint: disable=C0330
+        self, t_obs, n_i_obs, population, alpha=0.95, n_iter=1000, r0_ci=True,
+    ):  # pylint: disable=R0913
         """ Calculates the confidence interval of the parameters
         using the random sample bootstrap method.
 
@@ -119,7 +113,9 @@ class ConfidenceIntervalsMixin:
 
         return ci, p_bt
 
-    def ci_block_cv(self, t_obs, n_i_obs, population, lags=1, min_sample=3):
+    def ci_block_cv(
+        self, t_obs, n_i_obs, population, lags=1, min_sample=3  # pylint: disable=C0330
+    ):  # pylint: disable=R0913
         """ Calculates the confidence interval of the model parameters
         using a block cross validation appropriate for time series
         and differential systems when the value of the states in the


### PR DESCRIPTION
**Description**

This depends on #74 

This pull requests fixes the post regression routines that were previously valid only for the SIR model. Now, they can be used to any SIR-like model. 

model.py was again updated to include the attribute fit_index. As post-regression depends on regression, we ask the user to provide fit_index only the first time that she fits the model.

The SIR-X notebook was updated and now include a section on parameter fitting. This section is considerably longer and more explained than the one for the SIR model, as in SIR only one parameter was fitted while for SIR-X three parameters were fitted. Just as an interesting result, kappa_0 seems to be overfitting. I will create an issue with a wishlist for the next release, but we could add both the Akaike Information Criteria routine, and also to calculate a correlation matrix between model parameters to identify independent parameters.

The SIR notebook was updated as the previous post_regression was missing the last prediction, which made inconsistent array dimensions. Now this is corrected.

When #74 gets merged, I will rebase.

After this, I think that all the API will be solid as schwarzeneger abs. 