### PR TITLE
refactor(post_regression): ask parameters once and clarify pipeline

### DIFF
--- a/doc/tutorials/SIR-X.ipynb
+++ b/doc/tutorials/SIR-X.ipynb
@@ -210,7 +210,7 @@
     "G_sir = SIR()\n",
     "G_sir.set_params(p=params, initial_conds=w0)\n",
     "G_sir.fit_input=2\n",
-    "G_sir.fit(t_days, nX, N)\n",
+    "G_sir.fit(t_days, nX)\n",
     "G_sir.solve(t_days[-1], t_days[-1]+1)\n",
     "t_SIR = G_sir.fetch()[:,0]\n",
     "I_SIR = G_sir.fetch()[:,2]"
@@ -250,19 +250,10 @@
     "g_sirx.set_params(p=params, initial_conds=w0)\n",
     "# Fit all parameters\n",
     "fit_index=[False, False, True, True, True]\n",
-    "g_sirx.fit(t_days, nX, N, fit_index = fit_index)\n",
+    "g_sirx.fit(t_days, nX, fit_index = fit_index)\n",
     "g_sirx.solve(t_days[-1], t_days[-1]+1)\n",
     "t_sirx = g_sirx.fetch()[:,0]\n",
     "inf_sirx = g_sirx.fetch()[:,4]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.plot?"
    ]
   },
   {
@@ -332,7 +323,7 @@
    "outputs": [],
    "source": [
     "# Calculate confidence intervals\n",
-    "mse_avg, mse_list, p_list = g_sirx.ci_block_cv(t_days, nX, N, lags = 1, min_sample=3)"
+    "mse_avg, mse_list, p_list = g_sirx.ci_block_cv(t_days, nX, lags = 1, min_sample=3)"
    ]
   },
   {
@@ -369,21 +360,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "error",
-     "ename": "NameError",
-     "evalue": "name 'g_sirx' is not defined",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-1-0b09b1c0fb50>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[1;31m# Predict\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 2\u001b[1;33m \u001b[0mg_sirx\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msolve\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mt_days\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;33m-\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m+\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m\u001b[0mt_days\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;33m-\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m+\u001b[0m\u001b[1;36m2\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      3\u001b[0m \u001b[0mn_X_tplusone\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mg_sirx\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfetch\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;33m-\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m4\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Estimation of n_X_{t+1} = %.0f +- %.0f \"\u001b[0m \u001b[1;33m%\u001b[0m \u001b[1;33m(\u001b[0m\u001b[0mn_X_tplusone\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;36m2\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mmse_avg\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mNameError\u001b[0m: name 'g_sirx' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Predict\n",
     "g_sirx.solve(t_days[-1]+1,t_days[-1]+2)\n",
@@ -400,23 +379,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "output_type": "error",
-     "ename": "NameError",
-     "evalue": "name 'plt' is not defined",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-2-48e168c99f9a>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mplt\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfigure\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mfigsize\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;36m4\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m4\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      2\u001b[0m \u001b[0mplt\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mplot\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mmse_list\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;34m'ro'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      3\u001b[0m \u001b[0mplt\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mxlabel\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'Number of days used to predict the next day'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m \u001b[0mplt\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mylabel\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'MSE'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      5\u001b[0m \u001b[0mplt\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mshow\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mNameError\u001b[0m: name 'plt' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "plt.figure(figsize=[4,4])\n",
     "plt.plot(mse_list,'ro')\n",
@@ -533,6 +500,13 @@
     "\n",
     "After the peak of infections is reached, it is necessary to keep the quarantine and effective contact tracing for at least 30 days more."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/doc/tutorials/SIR-X.ipynb
+++ b/doc/tutorials/SIR-X.ipynb
@@ -526,7 +526,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4-final"
+   "version": "3.7.4"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/doc/tutorials/SIR-X.ipynb
+++ b/doc/tutorials/SIR-X.ipynb
@@ -323,7 +323,7 @@
    "outputs": [],
    "source": [
     "# Calculate confidence intervals\n",
-    "mse_avg, mse_list, p_list = g_sirx.ci_block_cv(t_days, nX, lags = 1, min_sample=3)"
+    "mse_avg, mse_list, p_list = g_sirx.ci_block_cv(lags = 1, min_sample=3)"
    ]
   },
   {

--- a/doc/tutorials/SIR.ipynb
+++ b/doc/tutorials/SIR.ipynb
@@ -514,7 +514,7 @@
     "# Define bootstrap options\n",
     "options = {\"alpha\":0.95, \"n_iter\":1000, \"r0_ci\":True}\n",
     "# Call bootstrap\n",
-    "par_ci, par_list = SIR_UK.ci_bootstrap(t_d, I_UK, **options)"
+    "par_ci, par_list = SIR_UK.ci_bootstrap(**options)"
    ]
   },
   {
@@ -619,7 +619,7 @@
    "source": [
     "# We previously imported ci_block_cv which provides a better prediction of the mean squared error of the predictions\n",
     "n_lags=1\n",
-    "MSE_avg, MSE_list, p_list = SIR_UK.ci_block_cv(t_d, I_UK, lags=n_lags, min_sample=3)\n"
+    "MSE_avg, MSE_list, p_list = SIR_UK.ci_block_cv(lags=n_lags, min_sample=3)\n"
    ]
   },
   {
@@ -759,7 +759,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4-final"
+   "version": "3.7.4"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/doc/tutorials/SIR.ipynb
+++ b/doc/tutorials/SIR.ipynb
@@ -252,7 +252,7 @@
     "my_SIR_fitted.set_params(params,w0)\n",
     "\n",
     "# Fit parameters\n",
-    "w = my_SIR_fitted.fit(days_list, Ealing_data, P_Ealing, fit_index=[True,False])\n",
+    "w = my_SIR_fitted.fit(days_list, Ealing_data, fit_index=[True,False])\n",
     "# Print the fitted reproduction rate\n",
     "print(\"Fitted reproduction rate R_0 = %.2f\" % my_SIR_fitted.r0)\n",
     "# Build the new solution\n",
@@ -460,7 +460,7 @@
     "SIR_UK = SIR()\n",
     "SIR_UK.set_params(p,n0_UK)\n",
     "# Train model\n",
-    "SIR_UK.fit(t_d, I_UK, P_UK)\n",
+    "SIR_UK.fit(t_d, I_UK)\n",
     "# Build numerical solution\n",
     "I_opt = SIR_UK.solve(n_days-1,n_days).fetch()[:,2]\n",
     "# lag = 6\n",
@@ -514,7 +514,7 @@
     "# Define bootstrap options\n",
     "options = {\"alpha\":0.95, \"n_iter\":1000, \"r0_ci\":True}\n",
     "# Call bootstrap\n",
-    "par_ci, par_list = SIR_UK.ci_bootstrap(t_d, I_UK, P_UK, **options)"
+    "par_ci, par_list = SIR_UK.ci_bootstrap(t_d, I_UK, **options)"
    ]
   },
   {
@@ -619,7 +619,7 @@
    "source": [
     "# We previously imported ci_block_cv which provides a better prediction of the mean squared error of the predictions\n",
     "n_lags=1\n",
-    "MSE_avg, MSE_list, p_list = SIR_UK.ci_block_cv(t_d, I_UK, P_UK, lags=n_lags, min_sample=3)\n"
+    "MSE_avg, MSE_list, p_list = SIR_UK.ci_block_cv(t_d, I_UK, lags=n_lags, min_sample=3)\n"
    ]
   },
   {
@@ -733,6 +733,13 @@
     "eps_avg = np.mean(MSE_list/I_UK[-7:])*100\n",
     "print(\"The average percentage deviation on the number of infected is %.1f%%\" % eps_avg)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -39,9 +39,12 @@ class Model(ConfidenceIntervalsMixin):
         self.p = None
         self.pop = None
         self.w0 = None
+        # Attributes setted after fitting
         self.pcov = None
         self.fit_input = None
         self.fit_index = None  # Store fitting info for post-regression analysis
+        self.t_obs = None
+        self.n_obs = None
 
     class InvalidParameterError(Exception):
         """Raised when an initial parameter of a value is not correct"""
@@ -161,7 +164,7 @@ class Model(ConfidenceIntervalsMixin):
         """
         return self.p[0] / self.p[1]
 
-    def fit(self, t_obs, n_obs, population, fit_index=None):
+    def fit(self, t_obs, n_obs, fit_index=None):
         """ Use the Levenberg-Marquardt algorithm to fit
         model parameters consistent with True entries in the fit_index list.
 
@@ -222,7 +225,7 @@ class Model(ConfidenceIntervalsMixin):
         # Define fixed parameters: this set of parameters won't be fitted
         # fixed_params = self.p[fix_index]
 
-        def function_handle(t, *par_fit, pop=population):
+        def function_handle(t, *par_fit, pop=self.pop):
             params = np.array(self.p)
             params[self.fit_index] = par_fit
             self.p = params

--- a/opensir/models/post_regression.py
+++ b/opensir/models/post_regression.py
@@ -3,13 +3,20 @@ import numpy as np
 from sklearn.utils import resample
 
 
-def _sort_resample(time_obs, n_i_obs):
+def _sort_resample(t_obs, n_obs):
     """
     Resamples and sort consistently an array
     of day times and cumulative number of
     infected
+
+    Args:
+        t_obs(numpy.array): time vector where the
+        resampling will be performed
+
+        n_obs(numpy.array): vector of number of
+        observations, consistent with t_obs.
     """
-    t_r, n_i_r = resample(time_obs, n_i_obs)
+    t_r, n_i_r = resample(t_obs, n_obs)
     n_i_r = np.array(n_i_r)
     # Sort and redefine arrays
     idx = np.argsort(t_r)
@@ -34,31 +41,21 @@ def _percentile_to_ci(alpha, p_bt):
 class ConfidenceIntervalsMixin:
     """ Mixin with confidence interval definitions """
 
-    def ci_bootstrap(  # pylint: disable=C0330
-        self, t_obs, n_i_obs, alpha=0.95, n_iter=1000, r0_ci=True,
-    ):  # pylint: disable=R0913
+    def ci_bootstrap(self, alpha=0.95, n_iter=1000, r0_ci=True):
         """ Calculates the confidence interval of the parameters
         using the random sample bootstrap method.
 
-        The model needs to be initialized with the parameters and
-        initial conditions
+        The model needs to be initialized and fitted prior calling
+        ci_bootstrap
 
         Args:
-            t_obs (list or np.array): List of days where the number of infected
-                where measured
-
-            n_i_obs (list or np.array): List with measurements of number of
-                infected people in a population. Must be consistent with t_obs.
-
-            population (int): Population size
-
             alpha (float): Percentile of the confidence interval required.
 
             n_iter (int): Number of random samples that will be taken to
-                fit the model and perform the bootstrapping.  Use n_iter >= 1000
+                fit the model and perform the bootstrapping. Use n_iter >= 1000
 
             r0_ci (boolean): Set to True to also return the reproduction
-                rate R_0 confidence interval.
+                rate confidence interval.
 
         Note:
             This traditional random sampling bootstrap is not a good way to
@@ -89,7 +86,7 @@ class ConfidenceIntervalsMixin:
 
         # Perform bootstraping
         for i in range(0, n_iter):  # pylint: disable=W0612
-            t_rs, n_i_rs = _sort_resample(t_obs, n_i_obs)
+            t_rs, n_i_rs = _sort_resample(self.postreg["t_obs"], self.postreg["n_obs"])
             w0_rs = [self.pop - n_i_rs[0], n_i_rs[0], 0]  # Still assume r0=0
             self.set_params(self.p, w0_rs)
             self.fit(t_rs, n_i_rs, self.fit_index)
@@ -113,9 +110,7 @@ class ConfidenceIntervalsMixin:
 
         return ci, p_bt
 
-    def ci_block_cv(
-        self, t_obs, n_i_obs, lags=1, min_sample=3  # pylint: disable=C0330
-    ):  # pylint: disable=R0913
+    def ci_block_cv(self, lags=1, min_sample=3):
         """ Calculates the confidence interval of the model parameters
         using a block cross validation appropriate for time series
         and differential systems when the value of the states in the
@@ -126,14 +121,6 @@ class ConfidenceIntervalsMixin:
         initial conditions
 
         Args:
-            t_obs (list or np.array): List of days where the number of infected
-                where measured
-
-            n_i_obs (list or np.parray): List with measurements of number of
-                infected people in a population. Must be consistent with t_obs.
-
-            population (int): population size
-
             lags (int): Defines the number of days that will be
                 forecasted to calculate the mean squared error. For
                 example, for the prediction Xp(t) and the real value
@@ -168,16 +155,21 @@ class ConfidenceIntervalsMixin:
         # Consider at least the three first datapoints
         p_list = []
         mse_list = []  # List of mean squared errors of the prediction for the time t+1
-        for i in range(min_sample, len(n_i_obs) - lags + 1):
+        for i in range(min_sample, len(self.postreg["n_obs"]) - lags + 1):
             # Fit model to a subset of the time-series data
-            self.fit(t_obs[0:i], n_i_obs[0:i], self.fit_index)
+            self.fit(
+                self.postreg["t_obs"][0:i], self.postreg["n_obs"][0:i], self.fit_index
+            )
             # Store the rolling parameters
             p_list.append(self.p)
             # Predict for the i + lags period
-            self.solve(t_obs[i - 1 + lags], numpoints=int(t_obs[i - 1 + lags]) + 1)
+            self.solve(
+                self.postreg["t_obs"][i - 1 + lags],
+                numpoints=int(self.postreg["t_obs"][i - 1 + lags]) + 1,
+            )
             pred = self.fetch()[:, self.fit_input]
             # Calculate mean squared errors
-            mse = np.sqrt((pred[-1] - n_i_obs[i - 1 + lags]) ** 2)
+            mse = np.sqrt((pred[-1] - self.postreg["n_obs"][i - 1 + lags]) ** 2)
             mse_list.append(mse)
 
         p_list = np.array(p_list)

--- a/opensir/models/post_regression.py
+++ b/opensir/models/post_regression.py
@@ -86,10 +86,12 @@ class ConfidenceIntervalsMixin:
 
         # Perform bootstraping
         for i in range(0, n_iter):  # pylint: disable=W0612
-            t_rs, n_i_rs = _sort_resample(self.postreg["t_obs"], self.postreg["n_obs"])
+            t_rs, n_i_rs = _sort_resample(
+                self.fit_attr["t_obs"], self.fit_attr["n_obs"]
+            )
             w0_rs = [self.pop - n_i_rs[0], n_i_rs[0], 0]  # Still assume r0=0
             self.set_params(self.p, w0_rs)
-            self.fit(t_rs, n_i_rs, self.fit_index)
+            self.fit(t_rs, n_i_rs, self.fit_attr["fit_index"])
             p_bt.append(self.p)
             if r0_ci:
                 r0_bt.append(self.r0)
@@ -155,21 +157,23 @@ class ConfidenceIntervalsMixin:
         # Consider at least the three first datapoints
         p_list = []
         mse_list = []  # List of mean squared errors of the prediction for the time t+1
-        for i in range(min_sample, len(self.postreg["n_obs"]) - lags + 1):
+        for i in range(min_sample, len(self.fit_attr["n_obs"]) - lags + 1):
             # Fit model to a subset of the time-series data
             self.fit(
-                self.postreg["t_obs"][0:i], self.postreg["n_obs"][0:i], self.fit_index
+                self.fit_attr["t_obs"][0:i],
+                self.fit_attr["n_obs"][0:i],
+                self.fit_attr["fit_index"],
             )
             # Store the rolling parameters
             p_list.append(self.p)
             # Predict for the i + lags period
             self.solve(
-                self.postreg["t_obs"][i - 1 + lags],
-                numpoints=int(self.postreg["t_obs"][i - 1 + lags]) + 1,
+                self.fit_attr["t_obs"][i - 1 + lags],
+                numpoints=int(self.fit_attr["t_obs"][i - 1 + lags]) + 1,
             )
-            pred = self.fetch()[:, self.fit_input]
+            pred = self.fetch()[:, self.fit_attr["fit_input"]]
             # Calculate mean squared errors
-            mse = np.sqrt((pred[-1] - self.postreg["n_obs"][i - 1 + lags]) ** 2)
+            mse = np.sqrt((pred[-1] - self.fit_attr["n_obs"][i - 1 + lags]) ** 2)
             mse_list.append(mse)
 
         p_list = np.array(p_list)

--- a/opensir/models/post_regression.py
+++ b/opensir/models/post_regression.py
@@ -35,7 +35,7 @@ class ConfidenceIntervalsMixin:
     """ Mixin with confidence interval definitions """
 
     def ci_bootstrap(  # pylint: disable=C0330
-        self, t_obs, n_i_obs, population, alpha=0.95, n_iter=1000, r0_ci=True,
+        self, t_obs, n_i_obs, alpha=0.95, n_iter=1000, r0_ci=True,
     ):  # pylint: disable=R0913
         """ Calculates the confidence interval of the parameters
         using the random sample bootstrap method.
@@ -90,9 +90,9 @@ class ConfidenceIntervalsMixin:
         # Perform bootstraping
         for i in range(0, n_iter):  # pylint: disable=W0612
             t_rs, n_i_rs = _sort_resample(t_obs, n_i_obs)
-            w0_rs = [population - n_i_rs[0], n_i_rs[0], 0]  # Still assume r0=0
+            w0_rs = [self.pop - n_i_rs[0], n_i_rs[0], 0]  # Still assume r0=0
             self.set_params(self.p, w0_rs)
-            self.fit(t_rs, n_i_rs, population, self.fit_index)
+            self.fit(t_rs, n_i_rs, self.fit_index)
             p_bt.append(self.p)
             if r0_ci:
                 r0_bt.append(self.r0)
@@ -114,7 +114,7 @@ class ConfidenceIntervalsMixin:
         return ci, p_bt
 
     def ci_block_cv(
-        self, t_obs, n_i_obs, population, lags=1, min_sample=3  # pylint: disable=C0330
+        self, t_obs, n_i_obs, lags=1, min_sample=3  # pylint: disable=C0330
     ):  # pylint: disable=R0913
         """ Calculates the confidence interval of the model parameters
         using a block cross validation appropriate for time series
@@ -170,7 +170,7 @@ class ConfidenceIntervalsMixin:
         mse_list = []  # List of mean squared errors of the prediction for the time t+1
         for i in range(min_sample, len(n_i_obs) - lags + 1):
             # Fit model to a subset of the time-series data
-            self.fit(t_obs[0:i], n_i_obs[0:i], population, self.fit_index)
+            self.fit(t_obs[0:i], n_i_obs[0:i], self.fit_index)
             # Store the rolling parameters
             p_list.append(self.p)
             # Predict for the i + lags period

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -96,7 +96,6 @@ class SIR(Model):
         Returns:
             SIR: Reference to self
         """
-        self.fit_input = 2  # By default, fit against infected
         if array:
             arr = np.array(array, dtype=float)
         else:
@@ -104,6 +103,7 @@ class SIR(Model):
 
         _validate_params(arr, SIR_NUM_PARAMS)
 
+        self.fit_input = 2  # By default, fit against infected
         self.p = arr
         return self
 

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -79,7 +79,9 @@ class SIRX(Model):
         Returns:
             SIRX: Reference to self
         """
-        self.fit_input = 4  # By default, fit against containment compartment X
+        # By default, fit against containment compartment X
+        self.fit_input = 4
+
         if array:
             arr = np.array(array, dtype=float)
         else:
@@ -127,7 +129,8 @@ class SIRX(Model):
             SIRX: Reference to self
         """
         super().set_params(p, initial_conds)
-        self.fit_input = 4  # By default, fit against containment compartment X
+        # By default, fit against containment compartment X
+        self.fit_input = 4
         return self
 
     def set_initial_conds(self, array=None, n_S0=None, n_I0=None, n_R0=None, n_X0=None):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -71,7 +71,6 @@ class TestModel:
 
         t_obs = np.array([0, 1, 2, 3, 4])
         n_i_obs = np.array([0, 10, 20])
-        pop = 1000
         # Test with a fit_index for an unrealistic
         # number of parameters
         model.p = [1, 2]
@@ -79,10 +78,10 @@ class TestModel:
 
         # Test inconsistent dimensions of t_obs and n_i_obs
         with pytest.raises(Model.InconsistentDimensionsError):
-            model.fit(t_obs, n_i_obs, pop)
+            model.fit(t_obs, n_i_obs)
         # Testinconsistent dimnesions between fit_index and self.p
         with pytest.raises(Model.InconsistentDimensionsError):
-            model.fit(t_obs[:3], n_i_obs, pop, fit_index)
+            model.fit(t_obs[:3], n_i_obs, fit_index)
 
     def test_input_validity(self, model):
         """ Test that providing negative times, negative number of


### PR DESCRIPTION
**Refactor fit and post regression functions to facilitate API usage & code testing**

Following the comments of @sasalatart on #76 regarding pylint complaining for the number of arguments, I refactored model, .fit and .set_params to ask for
parameters once. The typical usage of the API, as all our examples
show, follows this pipeline:

1. Build an empty model
2. Set parameters and initial conditions
3. Fit the model
4. Calculate confidence intervals.

Currently, we were asking the user for (t,X) on steps 3 and 4, and for the population on 3,4 but it was implicitely calculated on 2.  This PR refactors the code in a way that the population is calculated directly from the IC on 2, and we don't ask the user again twice. Additionally, (t,X) is asked only on step 3. This enables to ask the user three less parameters on fit and the post_regression routines.

**Commit f3d93f4** 
Ask the user for the population only once when building the model and using the set_params / set_parameters functions. Therafter, when fitting the population parameters is
no longer required as it will be stored in self.pop

**Commit e9558d6** 
This commit introduces a new dict attribute for the model,
called self.postreg. This dict stores user inputs from the
first call of the fit function: n_obs and t_obs, in a similar
way that fit_index is stored.

The functions model and post_regression are updated and the syntax
is considerably simplified, which should help code maintenance and
API usage.

The test_model.py is updated to consider that the fit function, from
the previous commits, use less parameters.

The notebooks SIR and SIR-X are updated to be consistent with these
changes.

This is the last building block (It took a while!) before finishing #70 and finally
being ready to go for the release
