### PR TITLE
feat(predictionresults): print and plot

### DIFF
--- a/doc/tutorials/SIR-X.ipynb
+++ b/doc/tutorials/SIR-X.ipynb
@@ -32,7 +32,8 @@
     "# Import packages\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -223,6 +224,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "ax = plt.axes()\n",
+    "ax.tick_params(axis=\"both\", which=\"major\", labelsize= 14 )\n",
     "plt.plot(t_SIR, I_SIR)\n",
     "plt.plot(t_days, nX, 'ro')\n",
     "plt.show()"
@@ -313,7 +316,7 @@
     "\n",
     "The three first parameters are the same as the fit function, while the last two parameters are the `lags` and the `min_sample`. The `lags` parameter indicates how many periods in the future will be forecasted in order to calculate the mean squared error of the model prediction. The `min_sample` parameter indicates the initial number of observations and days that will be taken to perform the block cross validation.\n",
     "\n",
-    "In the following example,`model.ci_block_cv` is used to estimate the average mean squared error of *1-day* predictions taking *3* observations as the starting point of the cross validation."
+    "In the following example, `model.ci_block_cv` is used to estimate the average mean squared error of *1-day* predictions taking *6* observations as the starting point of the cross validation. For Guangdong, a `min_sample=6` higher than the default 3 is required to handle well the missing data. This way, both the data on the four first days, and two days after the data starts again, are considered for cross validation."
    ]
   },
   {
@@ -323,23 +326,7 @@
    "outputs": [],
    "source": [
     "# Calculate confidence intervals\n",
-    "mse_avg, mse_list, p_list = g_sirx.ci_block_cv(lags = 1, min_sample=3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Amazing! let's print the average mean squared error (MSE) for one-day predictions:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"One day estimation of the mean squared error of SIR-X fitted to Guangdong Data = %.0f\" % mse_avg)"
+    "mse_avg, mse_list, p_list, pred_data = g_sirx.block_cv(lags = 1, min_sample = 6)"
    ]
   },
   {
@@ -348,13 +335,46 @@
    "source": [
     "If it is assumed that the residuals distribute normally, then a good estimation of a 95% confidence interval on the one-day prediction of the number of confirmed cases is \n",
     "\n",
-    "$$\\sigma \\sim \\mathrm{MSE} \\rightarrow n_{X,{t+1}} \\sim \\hat{n}_{X,{t+1}} \\pm 2 \\sigma$$ "
+    "$$\\sigma \\sim \\mathrm{MSE} \\rightarrow n_{X,{t+1}} \\sim \\hat{n}_{X,{t+1}} \\pm 2 \\sigma$$ \n",
+    "\n",
+    "Where $n_{X,{t+1}}$ is the real number of confirmed cases in the next day, and $\\hat{n}_{X,{t+1}}$ is the estimation using the SIR-X model using cross validation. We can use the `PredictionResults` instance `pred_data` functionality to explore the mean-squared errors and the predictions confidence intervals:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pred_data.print_mse()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The predictive accuracy of the model is quite impressive, even for 9-day predictions. Let's take advantage of the relatively low mean squared error to forecast a 10 days horizon with confidence intervals using `pred_data.plot_predictions(n_days=9)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "pred_data.plot_predictions(n_days=9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If it is assumed that the residuals distribute normally, then a good estimation of a 95% confidence interval on the one-day prediction of the number of confirmed cases is \n",
+    "\n",
+    "$$\\sigma \\sim \\mathrm{MSE} \\rightarrow n_{X,{t+1}} \\sim \\hat{n}_{X,{t+1}} \\pm 2 \\sigma$$ \n",
+    "\n",
     "Where $n_{X,{t+1}}$ is the real number of confirmed cases in the next day, and $\\hat{n}_{X,{t+1}}$ is the estimation using the SIR-X model using cross validation. We use solve to make a 1-day prediction and append the 95% confidence interval."
    ]
   },
@@ -367,28 +387,42 @@
     "# Predict\n",
     "g_sirx.solve(t_days[-1]+1,t_days[-1]+2)\n",
     "n_X_tplusone = g_sirx.fetch()[-1,4]\n",
-    "print(\"Estimation of n_X_{t+1} = %.0f +- %.0f \" % (n_X_tplusone, 2*mse_avg) )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "But the model seems to fit far better than this estimation. Fortunately, it is possible to explore the residuals of the block cross validation through the mse_list"
+    "print(\"Estimation of n_X_{t+1} = %.0f +- %.0f \" % (n_X_tplusone, 2*mse_avg[0]) )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [],
    "source": [
-    "plt.figure(figsize=[4,4])\n",
-    "plt.plot(mse_list,'ro')\n",
-    "plt.xlabel('Number of days used to predict the next day')\n",
-    "plt.ylabel('MSE')\n",
+    "# Transform parameter list into a DataFrame\n",
+    "par_block_cv = pd.DataFrame(p_list)\n",
+    "# Rename dataframe columns based on SIR-X parameter names\n",
+    "par_block_cv.columns = g_sirx.PARAMS\n",
+    "# Add the day. Note that we take the days from min_sample until the end of the array, as days\n",
+    "# 0,1,2 are used for the first sampling in the block cross-validation\n",
+    "par_block_cv['Day'] = t_days[5:]\n",
+    "# Explore formatted dataframe for parametric analysis\n",
+    "par_block_cv.head(len(p_list))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize = [5,5])\n",
+    "ax = plt.axes()\n",
+    "ax.tick_params(axis = \"both\", which = \"major\", labelsize = 14 )\n",
+    "plt.plot(mse_list[0],'ro')\n",
+    "plt.xlabel('Number of days used to predict the next day', size = 14)\n",
+    "plt.ylabel('MSE', size = 14)\n",
     "plt.show()"
    ]
   },
@@ -400,60 +434,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "after_missing_values_MSE = np.mean(mse_list[-8:])\n",
-    "print(\"New MSE = %.1f\" % after_missing_values_MSE)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Which provides a value that is more aligned with the spread observed in the previous plot."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Predict\n",
-    "g_sirx.solve(t_days[-1]+1,t_days[-1]+2)\n",
-    "n_X_tplusone = g_sirx.fetch()[-1,4]\n",
-    "print(\"Estimation of n_X_{t+1} = %.0f +- %.0f \" % (n_X_tplusone, 2*after_missing_values_MSE) )"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### Variation of fitted parameters\n",
     "\n",
     "Finally, it is possible to observe how the model parameters change as more days and number of confirmed cases are introduced in the block cross validation. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "# Transform parameter list into a DataFrame\n",
-    "par_block_cv = pd.DataFrame(p_list)\n",
-    "# Rename dataframe columns based on SIR-X parameter names\n",
-    "par_block_cv.columns = g_sirx.PARAMS\n",
-    "# Add the day. Note that we take the days from min_sample until the end of the array, as days\n",
-    "# 0,1,2 are used for the first sampling in the block cross-validation\n",
-    "par_block_cv['Day'] = t_days[3:]\n",
-    "# Explore formatted dataframe for parametric analysis\n",
-    "par_block_cv.head(len(p_list))"
    ]
   },
   {
@@ -527,7 +513,7 @@
    "source": [
     "Looking at the values of the number of infected and quarantined individuals, as well as the time of the peak, it is clear that both plots are in good agreement, which validates the customized plot created by the code cell below \"long term prediction\"."
    ]
-  }
+ }
  ],
  "metadata": {
   "file_extension": ".py",

--- a/doc/tutorials/SIR.ipynb
+++ b/doc/tutorials/SIR.ipynb
@@ -612,40 +612,114 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# We previously imported ci_block_cv which provides a better prediction of the mean squared error of the predictions\n",
-    "n_lags=1\n",
-    "MSE_avg, MSE_list, p_list = SIR_UK.ci_block_cv(lags=n_lags, min_sample=3)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"Bootstrapping parametric range\")\n",
-    "p_list"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"The average mean squared error on the time cross validation bootstrapping is: %.3f\" % MSE_avg)"
+    "### Evaluate model performance through block cross validation"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can visualize the results of the block bootstrapping in terms of the variation of the reproduction rate $R_0$ and the mean squared error when a subset of the days is taken. By default, ci_block_cv starts with the data of the three days, fit the model on that data, predicts the number of infected in the next period, calculate the mean squared error between the prediction and the test dataset, and stores it into two arrays. It repeats this until it uses the data of $(n-1)$ intervals to predict the $n-th$ latest observation of infections."
+    "A reliable approach to evaluate the predictive accuracy of a model which variables are time-dependent is to use block cross validation. In Open-SIR, it is implemented through the `model.block_cv` function. The inputs of the model is the minimum sample to use to perform the cross validation. The outputs of the model are lists with the average mean squared error, rolling mean squared error, evolution of the fitted parameters and a `PredictionResults` dataclass."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# We previously imported ci_block_cv which provides a better prediction of the mean squared error of the predictions\n",
+    "n_lags=1\n",
+    "MSE_avg, MSE_list, p_list, pred_data = SIR_UK.block_cv(lags=n_lags, min_sample=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This `pred_data` instance of the `PredictionResults` dataclass offers a simplified syntax to access details of the cross-validation test on model predictions. For instance, the member function `.print_mse()` prints a summary of the mean-squared errors for different forecasts horizons. The number of forecasts horizons provided is by default the length of the observations minus the min_sample parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pred_data.print_mse()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the residuals between the model and the observed data are normally distributed , the mean squared error is an estimator of the error variance. The member function `.plot_predictions(n_days)` offers a convenient ways to visualize short term predictions with an estimations of the 66% and 95% confidence intervals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pred_data.plot_predictions(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The robustness of the model fitting can be explored plotting the change of the parameters during the block cross validation. As the model is fitted with more and more recent data, a measure of robustness is the convergence of the model parameters to a particular value. The list `p_list` contains the information of all model parameters, which can be plotted to assess parameter convergence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Block cross validation parametric range\")\n",
+    "plt.plot(p_list[:,0],'ro')\n",
+    "plt.title(\"Variation of the parameter alpha through Block CV\")\n",
+    "plt.xlabel(\"Days\", size=14)\n",
+    "plt.ylabel(\"alpha\", size=14)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is clear that the $\\alpha$ parameter is converging to a value between 0.56 and 0.57 as time progresses. This results have to be reassessed as new data appears, as some fundamental change in the disease epidemiology or social distance may occur suddenly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `MSE_avg` list contains the mean squared errors for a forecast of the day $i+1$ since the fitting data ends. For example, the average mean squared error for one day predictions can be accessed on `MSE_avg[0]`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"The average mean squared error on the time cross validation bootstrapping is: %.3f\" % MSE_avg[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another way to visualize the results of the block cross-validation, is to observe the variation of the reproduction rate $R_0$ and the mean squared error when a subset of the days is taken. By default, `block_cv` starts with the data of three days, fit the model on that data, predicts the number of infected in the next period, calculate the mean squared error between the prediction and the test dataset, and stores it into two arrays. Afterwards, it computes the MSE of 2,3 and up to `len(n_obs)-min_sample` days to be forecasted. It repeats this until it uses the data of $(n-1)$ intervals to predict the $n-th$ latest observation of infections.\n",
+    "\n",
+    "In the next example, the list of the mean-squared errors for 1-day prediction is visualized"
    ]
   },
   {
@@ -660,16 +734,23 @@
     "\n",
     "plt.figure(figsize=[10,5])\n",
     "plt.subplot(1,2,1)\n",
-    "plt.plot(t_d[(2+n_lags):], r0_roll,'ro')\n",
+    "plt.plot(t_d[2:], r0_roll,'ro')\n",
     "plt.xlabel(\"Days used in the block to fit parameters\")\n",
     "plt.ylabel(\"Rolling $R_0$\")\n",
     "plt.title(\"Block bootstrapping change in $R_0$\")\n",
     "plt.subplot(1,2,2)\n",
-    "plt.plot(t_d[(2+n_lags):], MSE_list,'bo')\n",
+    "plt.plot(t_d[(2):-1], MSE_list[0],'bo')\n",
     "plt.xlabel(\"Days used in the block to fit parameters\")\n",
     "plt.ylabel(\"Mean squared error in number of infected\")\n",
     "plt.title(\"Block bootstrapping change in MSE\")\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Interestingly, it is hard to see any convergence on the change on mean-squared error."
    ]
   },
   {
@@ -678,7 +759,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"MSE_lastday = %.2f\" % MSE_list[-1])"
+    "print(\"MSE_lastday = %.2f\" % MSE_list[0][-1])"
    ]
   },
   {
@@ -713,7 +794,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "e_new = MSE_list[-1]/(I_UK[-1]-I_UK[-2])\n",
+    "e_new = MSE_list[0][-1]/(I_UK[-1]-I_UK[-2])\n",
     "print(\"The percentage error of the SIR model over the last day reported cases is %.1f%%\" % (100*e_new))"
    ]
   },
@@ -730,7 +811,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eps_avg = np.mean(MSE_list/I_UK[-7:])*100\n",
+    "eps_avg = np.mean(MSE_list[0]/I_UK[-7:])*100\n",
     "print(\"The average percentage deviation on the number of infected is %.1f%%\" % eps_avg)"
    ]
   },
@@ -760,7 +841,7 @@
    "source": [
     "my_SIR_fitted.plot()"
    ]
-  }
+ }
  ],
  "metadata": {
   "file_extension": ".py",

--- a/opensir/models/post_regression.py
+++ b/opensir/models/post_regression.py
@@ -7,8 +7,10 @@ from sklearn.utils import resample
 
 @dataclass
 class PredictionResults:
-    """Class which stores model predictions,
-    based on block cross-validation """
+    """
+    Class which stores model predictions,
+    based on block cross-validation
+    """
 
     pred: list  # List of out of sample predictions
     n_obs_end: float  # Last in-sample observation
@@ -20,9 +22,11 @@ class PredictionResults:
     # p_bt: list  # List of parameters sampled through bootstrap
 
     def print_mse(self):
-        """Prints a summary of model predictive
+        """
+        Prints a summary of model predictive
         performance measures for n_days forecasting
-        of the fitted variable """
+        of the fitted variable
+        """
 
         for i, j, k in zip(self.mse_avg, self.n_avg, range(1 + self.n_avg[0])):
             print(
@@ -31,8 +35,10 @@ class PredictionResults:
             )
 
     def plot_predictions(self, n_days=1):
-        """Plot predictions and confidence intervals
-        for the fitted variable"""
+        """
+        Plot predictions and confidence intervals
+        for the fitted variable
+        """
 
         t = np.linspace(1, 1 + n_days, n_days)
         pred_low_2s = self.pred - 2 * self.mse_avg
@@ -104,9 +110,12 @@ def _sort_resample(t_obs, n_obs):
 
 
 def _percentile_to_ci(alpha, p_bt):
-    """Input alpha and list of bootstrapped values
+    """
+    Input alpha and list of bootstrapped values
     for one parameter
-    Output: confidence intervals of the parameters """
+    Output: confidence intervals of the parameters
+    """
+
     p_low = ((1 - alpha) / 2) * 100
     p_up = (alpha + (1 - alpha) / 2) * 100
     # From the resulting distribution, extract the
@@ -281,9 +290,6 @@ class ConfidenceIntervalsMixin:
 
         # The first element of the prediction is out of the sample
         t_start = int(self.fit_attr["t_obs"][-1]) + 1
-
-        # pred = self.fetch()[t_start:, self.fit_attr["fit_input"]]
-        # n_obs_end = self.fetch()[t_start - 1, self.fit_attr["fit_input"]]
 
         # create PredictionResults dataclass
         pred_data = PredictionResults(

--- a/opensir/models/post_regression.py
+++ b/opensir/models/post_regression.py
@@ -1,6 +1,18 @@
 """Post regression utilities"""
+from dataclasses import dataclass
 import numpy as np
 from sklearn.utils import resample
+
+
+@dataclass
+class PredictionResults:
+    """Class which stores model predictions,
+    lists of parameters and fun stuff """
+
+    mse_avg: float  # MSE_avg after cross validation
+    mse_list: list  # List of sequential mse
+    p_cv: list  # List of parameters rolling-fitted through cross validation
+    # p_bt: list  # List of parameters sampled through bootstrap
 
 
 def _sort_resample(t_obs, n_obs):
@@ -112,15 +124,16 @@ class ConfidenceIntervalsMixin:
 
         return ci, p_bt
 
-    def ci_block_cv(self, lags=1, min_sample=3):
-        """ Calculates the confidence interval of the model parameters
-        using a block cross validation appropriate for time series
-        and differential systems when the value of the states in the
-        time (t+1) is not independent from the value of the states in the
-        time t.
+    def block_cv(self, lags=1, min_sample=3):
+        """ Calculates mean squared error of the predictions as a
+        measure of model predictive performance using block
+        cross validation.
 
-        The model needs to be initialized with the parameters and
-        initial conditions
+        The cross-validation mean squared error can be used to
+        estimate a confidence interval of model predictions.
+
+        The model needs to be initialized and fitted
+        prior calling block_cv.
 
         Args:
             lags (int): Defines the number of days that will be
@@ -183,4 +196,6 @@ class ConfidenceIntervalsMixin:
         self.p = p0
         self.w = w0
 
-        return mse_avg, mse_list, p_list
+        sol = PredictionResults(mse_avg, mse_list, p_list)
+
+        return mse_avg, mse_list, p_list, sol


### PR DESCRIPTION
This PR Depends on #77 

We had a 3.5h conversation with @jia200x yesterday and figured out a that the pipeline after fitting the model wasn't clean. First of all, we clarified the pipeline

## Open-SIR Data and Predictions Pipeline:

#### Fitting
-------
1. Create an empty model
2. Set IC and parameters
3. Fit the model
4. Calculate confidence interval -> CI Bootstrap
5. model.summary()
--------------------------
#### Predicting and model performance
--------------------------
6. Predict (depends on .fit() )
7. Block cross validation to calculate 
8. Calculate a broader range of predictions

This PR focuses on *7* and *8*. 1-4 are done and *5* is optional *6* should be a wrapper over model.solve.

The user has actually few access to the amazing model performance quantities that block_cv is calculating. Following the refactor of #77 and the recently introduced PredictionResults dataclass, this PR adds steriods on PredictionResults and block_cv.

The PR starts on b354330

block_cv is modified to generate more meaningful input with less input interaction. The user doesn't need to understand or input manually the lags to calculate the cross validation test. Instead, now block-cv calculates the MSE_avg and list of MSE for all possible lags:

`max_lags = len(n_obs) - min_sample`

A number of important model performance quantities aredefined and stored in an instance of the PredictionResults dataclass to facilitate user interaction and API usage.

The subsequent commits:
- Add a fancy print and very fancy plot which looks really good

![image](https://user-images.githubusercontent.com/33637198/80921490-9ee5ca00-8d6e-11ea-9bba-13b2c6676953.png)

- Update the Jupyter Notebooks and close the Pipeline