### PR TITLE
feat: add "predict" function

### DIFF
--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -14,7 +14,7 @@ def sir(w, t, p):
     where
         S: Fraction of the population susceptible to the infection
         I: Fraction on the population infected
-        R: Fraction of the population recovered
+        R: Fraction of the population removed
     t: Current time
     p: vector of parameter
 
@@ -51,7 +51,7 @@ class SIR(Model):
                 - T: current day
                 - S: Predicted number of susceptible
                 - I: Predicted number of infected
-                - R: Predicted number of recovered
+                - R: Predicted number of removed
         """
         return self.solve(n_days, n_days + 1).fetch()
 
@@ -66,7 +66,7 @@ class SIR(Model):
 
                 - n_S0: Total number of susceptible to the infection
                 - n_I0: Toral number of infected
-                - n_R0: Total number of recovered
+                - n_R0: Total number of removed
 
                 Note n_S0 + n_I0 + n_R0 = Population
 
@@ -131,7 +131,7 @@ class SIR(Model):
 
                 - n_S0: Total number of susceptible to the infection
                 - n_I0: Total number of infected
-                - n_R0: Total number of recovered
+                - n_R0: Total number of removed
 
                 Note: n_S0 + n_I0 + n_R0 = Population
 

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -41,7 +41,7 @@ class SIR(Model):
     NAME = "SIR"
 
     def predict(self, n_days=7):
-        """ Predict Susceptible, Infected and Recovered
+        """ Predict Susceptible, Infected and Removed
 
         Args:
             n_days (int): number of days to predict

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -40,6 +40,21 @@ class SIR(Model):
     IC = ["n_S0", "n_I0", "n_R0"]
     NAME = "SIR"
 
+    def predict(self, n_days=7):
+        """ Predict Susceptible, Infected and Recovered
+
+        Args:
+            n_days (int): number of days to predict
+
+        Returns:
+            np.array: Array with:
+                - T: current day
+                - S: Predicted number of susceptible
+                - I: Predicted number of infected
+                - R: Predicted number of recovered
+        """
+        return self.solve(n_days, n_days + 1).fetch()
+
     def set_params(self, p, initial_conds):
         """ Set model parameters.
 

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -48,7 +48,8 @@ class SIR(Model):
 
         Returns:
             np.array: Array with:
-                - T: current day
+                - T: days of the predictions, where T[0] represents the last
+                  day of the sample and T[1] onwards the predictions.
                 - S: Predicted number of susceptible
                 - I: Predicted number of infected
                 - R: Predicted number of removed

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -62,7 +62,8 @@ class SIRX(Model):
 
         Returns:
             np.array: Array with:
-                - T: current day
+                - T: days of the predictions, where T[0] represents the last
+                  day of the sample and T[1] onwards the predictions.
                 - S: Predicted number of susceptible
                 - I: Predicted number of infected
                 - R: Predicted number of removed

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -16,7 +16,7 @@ def sirx(w, t, p):
     where
         S: Fraction of the population susceptible to the infection
         I: Fraction on the population infected
-        R: Fraction of the population that recovered
+        R: Fraction of the population that removed
         X: Fraction of the population that is quarantined
 
     t: time
@@ -65,7 +65,7 @@ class SIRX(Model):
                 - T: current day
                 - S: Predicted number of susceptible
                 - I: Predicted number of infected
-                - R: Predicted number of recovered
+                - R: Predicted number of removed
                 - X: Predicted number of quarantined
         """
         return self.solve(n_days, n_days + 1).fetch()
@@ -117,7 +117,7 @@ class SIRX(Model):
 
                 - n_S0: Total number of susceptible to the infection
                 - n_I0: Total number of infected
-                - n_R0: Total number of recovered
+                - n_R0: Total number of removed
                 - n_X0: Total number of quarantined
 
                 Note: n_S0 + n_I0 + n_R0 + n_X0 = Population
@@ -155,7 +155,7 @@ class SIRX(Model):
 
                 - n_S0: Total number of susceptible to the infection
                 - n_I0: Total number of infected
-                - n_R0: Total number of recovered
+                - n_R0: Total number of removed
                 - n_X0: Total number of quarantined
 
                 Note: n_S0 + n_I0 + n_R0 + n_X0 = Population

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -54,6 +54,22 @@ class SIRX(Model):
     IC = ["n_S0", "n_I0", "n_R0", "n_X0"]
     NAME = "SIRX"
 
+    def predict(self, n_days=7):
+        """ Predict Susceptible, Infected and Recovered
+
+        Args:
+            n_days (int): number of days to predict
+
+        Returns:
+            np.array: Array with:
+                - T: current day
+                - S: Predicted number of susceptible
+                - I: Predicted number of infected
+                - R: Predicted number of recovered
+                - X: Predicted number of quarantined
+        """
+        return self.solve(n_days, n_days + 1).fetch()
+
     def set_parameters(
         self,
         array=None,

--- a/tests/test_sir.py
+++ b/tests/test_sir.py
@@ -57,6 +57,18 @@ class TestUnittestSir:
     def model(self):
         return SIR()
 
+    def test_predict(self, model):
+        t = 6
+        model.set_params(DEFAULT_PARAMS, EALING_IC)
+        model.solve(t, t + 1)
+        m_list = model.fetch()
+
+        new_model = SIR()
+        new_model.set_params(DEFAULT_PARAMS, EALING_IC)
+        new_list = new_model.predict(t)
+
+        assert np.array_equal(new_list, m_list)
+
     def test_dict_and_list_params_produce_same_results(self, model):
         t = 6
         model.set_params(DEFAULT_PARAMS, EALING_IC)

--- a/tests/test_sirx.py
+++ b/tests/test_sirx.py
@@ -69,6 +69,18 @@ class TestUnittestSir:
     def model(self):
         return SIRX()
 
+    def test_predict(self, model):
+        t = 6
+        model.set_params(DEFAULT_PARAMS, GUANGDONG_IC)
+        model.solve(t, t + 1)
+        m_list = model.fetch()
+
+        new_model = SIRX()
+        new_model.set_params(DEFAULT_PARAMS, GUANGDONG_IC)
+        new_list = new_model.predict(t)
+
+        assert np.array_equal(new_list, m_list)
+
     def test_dict_and_list_params_produce_same_results(self, model):
         t = 6
         model.set_params(DEFAULT_PARAMS, GUANGDONG_IC)


### PR DESCRIPTION
## Contribution description

This PR adds a function to predict data.

This is simply a wrapper for "solve", but it will be preferred over "solve" when used for predicting data from the last "fit" step.
I also added some tests to make sure that they produce the same output as "solve".

## Testing procedure
`pipenv run test` shouldn't fail.
- Check that documentation builds properly