### PR TITLE
feat(model): plot

### DIFF
--- a/doc/tutorials/SIR-X.ipynb
+++ b/doc/tutorials/SIR-X.ipynb
@@ -57,7 +57,8 @@
    "outputs": [],
    "source": [
     "# Source data from John Hokpins university reposotiry\n",
-    "jhu_link = \"https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/who_covid_19_situation_reports/who_covid_19_sit_rep_time_series/who_covid_19_sit_rep_time_series.csv\"\n",
+    "# jhu_link = \"https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/who_covid_19_situation_reports/who_covid_19_sit_rep_time_series/who_covid_19_sit_rep_time_series.csv\"\n",
+    "jhu_link = \"https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv\"\n",
     "jhu_df = pd.read_csv(jhu_link)\n",
     "# Explore the dataset\n",
     "jhu_df.head(10)"
@@ -87,8 +88,8 @@
    "source": [
     "China = jhu_df[jhu_df[jhu_df.columns[1]]==\"China\"]\n",
     "city_name = \"Guangdong\"\n",
-    "city = China[China[\"Province/States\"] == city_name]\n",
-    "city = city.drop(columns=[\"Province/States\", \"Country/Region\", \"WHO region\",])\n",
+    "city = China[China[\"Province/State\"] == city_name]\n",
+    "city = city.drop(columns=[\"Province/State\", \"Country/Region\", \"Lat\",\"Long\"])\n",
     "time_index = pd.to_datetime(city.columns)\n",
     "data = city.values\n",
     "# Visualize the time\n",
@@ -170,13 +171,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The missing data between the 25th of January and the 31st of January doesn't prevent to fit the SIR-X model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Setting up SIR and SIR-X models"
    ]
   },
@@ -217,6 +211,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Try to fit a SIR model to Guangdong data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -231,7 +232,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The SIR model is clearly not appropriate to fit this data. We will repeat the process with a SIR-X model"
+    "The SIR model is clearly not appropriate to fit this data, as it cannot resolve the effect of exogeneous containment efforts such as quarantines or lockdown. We will repeat the process with a SIR-X model."
    ]
   },
   {
@@ -271,7 +272,6 @@
     "plt.title(\"SARS-CoV-2 evolution in Guangdong, China\", size=15)\n",
     "plt.xlabel('Days', fontsize=14)\n",
     "plt.ylabel('COVID-19 confirmed cases', fontsize=14)\n",
-    "ax.grid(True)\n",
     "ax.tick_params(axis='both', which='major', labelsize=14)\n",
     "plt.show()"
    ]
@@ -460,7 +460,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is clear to observe that after day 5 all parameters except kappa begin to converge. Therefore, care must be taken when performing inference over the parameter kappa."
+    "It is clear to observe that after day 15 all parameters except kappa begin to converge. Therefore, care must be taken when performing inference over the parameter kappa."
    ]
   },
   {

--- a/doc/tutorials/SIR-X.ipynb
+++ b/doc/tutorials/SIR-X.ipynb
@@ -502,11 +502,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Validate using model.plot()\n",
+    "\n",
+    "The function `model.plot()` offers a handy way to visualize model fitting and predictions. Custom visualizations can be validated against the `model.plot()` function."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "g_sirx.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looking at the values of the number of infected and quarantined individuals, as well as the time of the peak, it is clear that both plots are in good agreement, which validates the customized plot created by the code cell below \"long term prediction\"."
+   ]
   }
  ],
  "metadata": {

--- a/doc/tutorials/SIR.ipynb
+++ b/doc/tutorials/SIR.ipynb
@@ -735,11 +735,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualize long term predictions"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "long_time=90\n",
+    "SIR_UK.solve(long_time, long_time+1)\n",
+    "SIR_UK.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_SIR_fitted.plot()"
+   ]
   }
  ],
  "metadata": {

--- a/opensir/models/model.py
+++ b/opensir/models/model.py
@@ -54,6 +54,10 @@ class Model(ConfidenceIntervalsMixin):
         of fit_index has a length different than the length
         of the parameter array self.p"""
 
+    class InitializationError(Exception):
+        """Raised when a function executed violating the
+        logical sequence of the Open-SIR pipeline"""
+
     @property
     def _model(self):
         raise Exception()

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -159,8 +159,9 @@ class SIR(Model):
         color = "tab:red"
         ax1.set_xlabel("Time / days", size=14)
         ax1.set_ylabel("Number of infected", size=14)
-        ax1.plot(t, n_i, color=color)
+        ax1.plot(t, n_i, color=color, linewidth=4)
         ax1.tick_params(axis="y", labelcolor=color)
+        ax1.yaxis.label.set_color(color)
         ax1.tick_params(axis="both", labelsize=13)
 
         ax2 = ax1.twinx()  # instantiate a second axis that shares the x coordinate
@@ -169,7 +170,10 @@ class SIR(Model):
         ax2.set_ylabel("Number of removed", size=14)
         ax2.plot(t, n_r, color=color, linestyle=":", linewidth=4)
         ax2.tick_params(axis="y", labelcolor=color)
+        ax2.yaxis.label.set_color(color)
         ax2.tick_params(axis="both", labelsize=13)
+
+        plt.xlim(t[0], t[-1])
 
         plt.title("SIR model predictions", size=16)
         plt.show()

--- a/opensir/models/sir.py
+++ b/opensir/models/sir.py
@@ -1,5 +1,6 @@
 """Contains class and ODE system of SIR model"""
 import numpy as np
+import matplotlib.pyplot as plt
 from .model import Model, _validate_params
 
 SIR_NUM_PARAMS = 2
@@ -143,6 +144,35 @@ class SIR(Model):
         self.pop = np.sum(arr)
         self.w0 = arr / self.pop
         return self
+
+    def plot(self):
+        if self.sol is None:
+            raise self.InitializationError(
+                "Model must be either solved or fitted before plotting"
+            )
+
+        t = self.fetch()[:, 0]
+        n_i = self.fetch()[:, 2]
+        n_r = self.fetch()[:, 3]
+        fig, ax1 = plt.subplots(figsize=[5, 5])
+
+        color = "tab:red"
+        ax1.set_xlabel("Time / days", size=14)
+        ax1.set_ylabel("Number of infected", size=14)
+        ax1.plot(t, n_i, color=color)
+        ax1.tick_params(axis="y", labelcolor=color)
+        ax1.tick_params(axis="both", labelsize=13)
+
+        ax2 = ax1.twinx()  # instantiate a second axis that shares the x coordinate
+
+        color = "tab:blue"
+        ax2.set_ylabel("Number of removed", size=14)
+        ax2.plot(t, n_r, color=color, linestyle=":", linewidth=4)
+        ax2.tick_params(axis="y", labelcolor=color)
+        ax2.tick_params(axis="both", labelsize=13)
+
+        plt.title("SIR model predictions", size=16)
+        plt.show()
 
     @property
     def _model(self):

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -1,6 +1,7 @@
 """Contains class and ODE system of SIR-X model"""
-from .model import Model, _validate_params
+import matplotlib.pyplot as plt
 import numpy as np
+from .model import Model, _validate_params
 
 SIRX_NUM_PARAMS = 5
 SIRX_NUM_IC = 4
@@ -171,6 +172,36 @@ class SIRX(Model):
         self.pop = np.sum(arr)
         self.w0 = arr / self.pop
         return self
+
+    def plot(self):
+        if self.sol is None:
+            raise self.InitializationError(
+                "Model must be either solved or fitted before plotting"
+            )
+
+        t = self.fetch()[:, 0]
+        n_i = self.fetch()[:, 2]
+        n_x = self.fetch()[:, 4]
+
+        fig, ax1 = plt.subplots(figsize=[5, 5])
+
+        color = "tab:red"
+        ax1.set_xlabel("Time / days", size=14)
+        ax1.set_ylabel("Number of infected $N_I$", size=14)
+        ax1.plot(t, n_i, color=color)
+        ax1.tick_params(axis="y", labelcolor=color)
+        ax1.tick_params(axis="both", labelsize=13)
+
+        ax2 = ax1.twinx()  # instantiate a second axis that shares the x coordinate
+
+        color = "tab:blue"
+        ax2.set_ylabel("Number of quarantined $N_X$", size=14)
+        ax2.plot(t, n_x, color=color, linestyle=":", linewidth=4)
+        ax2.tick_params(axis="y", labelcolor=color)
+        ax2.tick_params(axis="both", labelsize=13)
+
+        plt.title("SIR-X model predictions", size=16)
+        plt.show()
 
     def _update_ic(self):
         """Updates i_0 = (i_0/x_0)*x_0 in the context

--- a/opensir/models/sirx.py
+++ b/opensir/models/sirx.py
@@ -188,8 +188,9 @@ class SIRX(Model):
         color = "tab:red"
         ax1.set_xlabel("Time / days", size=14)
         ax1.set_ylabel("Number of infected $N_I$", size=14)
-        ax1.plot(t, n_i, color=color)
+        ax1.plot(t, n_i, color=color, linewidth=4)
         ax1.tick_params(axis="y", labelcolor=color)
+        ax1.yaxis.label.set_color(color)
         ax1.tick_params(axis="both", labelsize=13)
 
         ax2 = ax1.twinx()  # instantiate a second axis that shares the x coordinate
@@ -198,7 +199,10 @@ class SIRX(Model):
         ax2.set_ylabel("Number of quarantined $N_X$", size=14)
         ax2.plot(t, n_x, color=color, linestyle=":", linewidth=4)
         ax2.tick_params(axis="y", labelcolor=color)
+        ax2.yaxis.label.set_color(color)
         ax2.tick_params(axis="both", labelsize=13)
+
+        plt.xlim(t[0], t[-1])
 
         plt.title("SIR-X model predictions", size=16)
         plt.show()


### PR DESCRIPTION
Equivalent to the [Utah Teapot](https://en.wikipedia.org/wiki/Utah_teapot)

`model.plot()` generates a plot from the calculated solution with the most relevant quantities for each of our models:

- SIR: (t vs I and R)
![image](https://user-images.githubusercontent.com/33637198/81120701-2e34de00-8f25-11ea-899b-70e508adc404.png)

- SIR-X: (t vs I and X)
![image](https://user-images.githubusercontent.com/33637198/81120655-14939680-8f25-11ea-9f1c-cc8e604fa0ad.png)


Calling `model.plot` requires the model to be either solved or fitted (because fitted -> solved).

Tests & updated README and docs will come soon. This will create a user friendly way for our users to validate the correct behaviour of open-sir against their parameters & fitting.