### PR TITLE
chore: add nb_black formatter

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ sphinx-rtd-theme = "*"
 toml = "*"
 pandas = "*"
 nbsphinx = "*"
+nb-black = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "58f9e6e4ae0e98386eb4afeb0efcb1fc47ad91a4cdda639a9d9d3c2625de5ba4"
+            "sha256": "e8d009fe2369bfc36a3226556905a071d635acd23965353c031cb8980ce6ac71"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,6 +22,13 @@
                 "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"
             ],
             "version": "==0.7.12"
+        },
+        "appdirs": {
+            "hashes": [
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            ],
+            "version": "==1.4.4"
         },
         "async-generator": {
             "hashes": [
@@ -46,24 +53,31 @@
         },
         "backcall": {
             "hashes": [
-                "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
-                "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"
+                "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e",
+                "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"
             ],
-            "version": "==0.1.0"
+            "version": "==0.2.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
+                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+            ],
+            "version": "==19.10b0"
         },
         "bleach": {
             "hashes": [
-                "sha256:cc8da25076a1fe56c3ac63671e2194458e0c4d9c7becfd52ca251650d517903c",
-                "sha256:e78e426105ac07026ba098f04de8abe9b6e3e98b5befbf89b51a5ef0a4292b03"
+                "sha256:2bce3d8fab545a6528c8fa5d9f9ae8ebc85a56da365c7f85180bfe96a35ef22f",
+                "sha256:3c4c520fdb9db59ef139915a5db79f8b51bc2a7257ea0389f30c846883430a4b"
             ],
-            "version": "==3.1.4"
+            "version": "==3.1.5"
         },
         "certifi": {
             "hashes": [
-                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
-                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
             ],
-            "version": "==2020.4.5.1"
+            "version": "==2020.6.20"
         },
         "chardet": {
             "hashes": [
@@ -71,6 +85,21 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+            ],
+            "version": "==7.1.2"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
+                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.3"
         },
         "cycler": {
             "hashes": [
@@ -88,10 +117,10 @@
         },
         "defusedxml": {
             "hashes": [
-                "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
-                "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
+                "sha256:8ede8ba04cf5bf7999e1492fa77df545db83717f52c5eab625f97228ebd539bf",
+                "sha256:aa621655d72cdd30f57073893b96cd0c3831a85b08b8e4954531bdac47e3e8c8"
             ],
-            "version": "==0.6.0"
+            "version": "==0.7.0rc1"
         },
         "docutils": {
             "hashes": [
@@ -109,10 +138,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
-                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.9"
+            "version": "==2.10"
         },
         "imagesize": {
             "hashes": [
@@ -123,25 +152,25 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
+                "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83",
+                "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
+            "version": "==1.7.0"
         },
         "ipykernel": {
             "hashes": [
-                "sha256:37c65d2e2da3326e5cf114405df6d47d997b8a3eba99e2cc4b75833bf71a5e18",
-                "sha256:39746b5f7d847a23fae4eac893e63e3d9cc5f8c3a4797fcd3bfa8d1a296ec6ed"
+                "sha256:0a5f1fc6f63241b9710b5960d314ffe44d8a18bf6674e3f28d2542b192fa318c",
+                "sha256:89dc4bd19c7781f6d7eef0e666c59ce57beac56bb39b511544a71397b7b31cbb"
             ],
-            "version": "==5.2.0"
+            "version": "==5.3.2"
         },
         "ipython": {
             "hashes": [
-                "sha256:ca478e52ae1f88da0102360e57e528b92f3ae4316aabac80a2cd7f7ab2efb48a",
-                "sha256:eb8d075de37f678424527b5ef6ea23f7b80240ca031c2dd6de5879d687a65333"
+                "sha256:2dbcc8c27ca7d3cfe4fcdff7f45b27f9a8d3edfa70ff8024a71c7a8eb5f09d64",
+                "sha256:9f4fcb31d3b2c533333893b9172264e4821c1ac91839500f31bd43f2c59b3ccf"
             ],
-            "version": "==7.13.0"
+            "version": "==7.16.1"
         },
         "ipython-genutils": {
             "hashes": [
@@ -159,10 +188,10 @@
         },
         "jedi": {
             "hashes": [
-                "sha256:b4f4052551025c6b0b0b193b29a6ff7bdb74c52450631206c262aef9f7159ad2",
-                "sha256:d5c871cb9360b414f981e7072c52c33258d598305280fef91c6cae34739d65d5"
+                "sha256:1ddb0ec78059e8e27ec9eb5098360b4ea0a3dd840bedf21415ea820c21b40a22",
+                "sha256:807d5d4f96711a2bcfdd5dfa3b1ae6d09aa53832b182090b222b5efb81f52f63"
             ],
-            "version": "==0.16.0"
+            "version": "==0.17.1"
         },
         "jinja2": {
             "hashes": [
@@ -173,10 +202,10 @@
         },
         "joblib": {
             "hashes": [
-                "sha256:0630eea4f5664c463f23fbf5dcfc54a2bc6168902719fa8e19daf033022786c8",
-                "sha256:bdb4fd9b72915ffb49fde2229ce482dd7ae79d842ed8c2b4c932441495af1403"
+                "sha256:8f52bf24c64b608bf0b2563e0e47d6fcf516abc8cfafe10cfd98ad66d94f92d6",
+                "sha256:d348c5d4ae31496b2aa060d6d9b787864dd204f9480baaa52d18850cb43e9f49"
             ],
-            "version": "==0.14.1"
+            "version": "==0.16.0"
         },
         "jsonschema": {
             "hashes": [
@@ -196,10 +225,10 @@
         },
         "jupyter-client": {
             "hashes": [
-                "sha256:5724827aedb1948ed6ed15131372bc304a8d3ad9ac67ac19da7c95120d6b17e0",
-                "sha256:81c1c712de383bf6bf3dab6b407392b0d84d814c7bd0ce2c7035ead8b2ffea97"
+                "sha256:5099cda1ac86b27b655a715c51e15bdc8bd9595b2b17adb41a2bd446bbbafc4a",
+                "sha256:9f0092a0951d878e7521924899e1fba6f689c7a99d43735a4c0bc05c6f311452"
             ],
-            "version": "==6.1.2"
+            "version": "==6.1.5"
         },
         "jupyter-console": {
             "hashes": [
@@ -217,22 +246,25 @@
         },
         "jupyterlab-pygments": {
             "hashes": [
-                "sha256:31deda75bd11b014190764c79f6199aa04ef2d4cf35c1c94270fc2e19c23a5c5",
-                "sha256:cc15f2a9850899d108a3c22743a86edcd3b42791a6c88b6e5b558d021d14d065"
+                "sha256:19a0ccde7daddec638363cd3d60b63a4f6544c9181d65253317b2fb492a797b9",
+                "sha256:c9535e5999f29bff90bd0fa423717dcaf247b71fad505d66b17d3217e9021fc5"
             ],
-            "version": "==0.1.0"
+            "version": "==0.1.1"
         },
         "kiwisolver": {
             "hashes": [
                 "sha256:03662cbd3e6729f341a97dd2690b271e51a67a68322affab12a5b011344b973c",
                 "sha256:18d749f3e56c0480dccd1714230da0f328e6e4accf188dd4e6884bdd06bf02dd",
                 "sha256:247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f",
+                "sha256:38d05c9ecb24eee1246391820ed7137ac42a50209c203c908154782fced90e44",
                 "sha256:443c2320520eda0a5b930b2725b26f6175ca4453c61f739fef7a5847bd262f74",
                 "sha256:4eadb361baf3069f278b055e3bb53fa189cea2fd02cb2c353b7a99ebb4477ef1",
                 "sha256:556da0a5f60f6486ec4969abbc1dd83cf9b5c2deadc8288508e55c0f5f87d29c",
                 "sha256:603162139684ee56bcd57acc74035fceed7dd8d732f38c0959c8bd157f913fec",
                 "sha256:60a78858580761fe611d22127868f3dc9f98871e6fdf0a15cc4203ed9ba6179b",
+                "sha256:63f55f490b958b6299e4e5bdac66ac988c3d11b7fafa522800359075d4fa56d1",
                 "sha256:7cc095a4661bdd8a5742aaf7c10ea9fac142d76ff1770a0f84394038126d8fc7",
+                "sha256:be046da49fbc3aa9491cc7296db7e8d27bcf0c3d5d1a40259c10471b014e4e0c",
                 "sha256:c31bc3c8e903d60a1ea31a754c72559398d91b5929fcb329b1c3a3d3f6e72113",
                 "sha256:c955791d80e464da3b471ab41eb65cf5a40c15ce9b001fdc5bbc241170de58ec",
                 "sha256:d069ef4b20b1e6b19f790d00097a5d5d2c50871b66d10075dab78938dc2ee2cf",
@@ -272,23 +304,24 @@
         },
         "matplotlib": {
             "hashes": [
-                "sha256:2466d4dddeb0f5666fd1e6736cc5287a4f9f7ae6c1a9e0779deff798b28e1d35",
-                "sha256:282b3fc8023c4365bad924d1bb442ddc565c2d1635f210b700722776da466ca3",
-                "sha256:4bb50ee4755271a2017b070984bcb788d483a8ce3132fab68393d1555b62d4ba",
-                "sha256:56d3147714da5c7ac4bc452d041e70e0e0b07c763f604110bd4e2527f320b86d",
-                "sha256:7a9baefad265907c6f0b037c8c35a10cf437f7708c27415a5513cf09ac6d6ddd",
-                "sha256:aae7d107dc37b4bb72dcc45f70394e6df2e5e92ac4079761aacd0e2ad1d3b1f7",
-                "sha256:af14e77829c5b5d5be11858d042d6f2459878f8e296228c7ea13ec1fd308eb68",
-                "sha256:c1cf735970b7cd424502719b44288b21089863aaaab099f55e0283a721aaf781",
-                "sha256:ce378047902b7a05546b6485b14df77b2ff207a0054e60c10b5680132090c8ee",
-                "sha256:d35891a86a4388b6965c2d527b9a9f9e657d9e110b0575ca8a24ba0d4e34b8fc",
-                "sha256:e06304686209331f99640642dee08781a9d55c6e32abb45ed54f021f46ccae47",
-                "sha256:e20ba7fb37d4647ac38f3c6d8672dd8b62451ee16173a0711b37ba0ce42bf37d",
-                "sha256:f4412241e32d0f8d3713b68d3ca6430190a5e8a7c070f1c07d7833d8c5264398",
-                "sha256:ffe2f9cdcea1086fc414e82f42271ecf1976700b8edd16ca9d376189c6d93aee"
+                "sha256:1a05eeb5a5f9f35a0d69a01c9efc9ca48e6d6fdc907da8fbad28b33bc839905b",
+                "sha256:2382d2a2df7ec99f92843161ce4c7bb54189a4aeb139c16baf92fa3f5c930ade",
+                "sha256:28c3b07079343d7be300cf4e33f95a700a2bb0fefa7cce05e8016a0c15e3f7bc",
+                "sha256:2ae5f279e6d9afc25cde907c514b2819bbd8a59551c883aa96777077635127ef",
+                "sha256:44d5f9c556a06566e572c31e977fe750cc5fc25ad1983b99dbb0c9cb373ecc78",
+                "sha256:6ca6bf7e10c9387d3ce4b6c2faae28cba404d0824c3dc40072f00919dff9015e",
+                "sha256:7010a0cc96303b7f7b436367fe58f37ca92a89e864202c43c3a284bdde26baf1",
+                "sha256:9da4ad25ed5e1786b24ee19aa2caedcde6a31844521d6b546dafd418b87c3c6c",
+                "sha256:9fef911a7cd3f36707c3cd812030e09a7d4f557b4d3d964e6a4ca782dddb11de",
+                "sha256:a53494c7e29139d96eccbbc91dd281382b6219645d91422046b494b3f24a2774",
+                "sha256:b2425f5ab2914ccc7dde37d7811a7fdf5284bf9e6dfa72ac649da1f1a13db550",
+                "sha256:bcc4803720e58ace1e51009015899248b7d64eecb02e4838516a47a9934a190f",
+                "sha256:d3e7a68de6e74f1f2936ea64d327733876d50aa6b1c0e0c7d51de19391204426",
+                "sha256:e5c4a30195bf262284ec3a4e28f0f8c31898f66d7124e143f851ffa981af291b",
+                "sha256:e7c54447ffd658099f2fb14e0e70a19eced523ce8caae38e65cec2fa807c3050"
             ],
             "index": "pypi",
-            "version": "==3.2.1"
+            "version": "==3.3.0rc1"
         },
         "mistune": {
             "hashes": [
@@ -297,104 +330,116 @@
             ],
             "version": "==0.8.4"
         },
+        "nb-black": {
+            "hashes": [
+                "sha256:1ca52e3a46675f6a0a6d79ac73a1f8f951bef60f919eced56173e76ab1b6d62b"
+            ],
+            "index": "pypi",
+            "version": "==1.0.7"
+        },
         "nbclient": {
             "hashes": [
-                "sha256:193731fd5039061dbd7d6d3f765a2fa59d23012594d68b1798deea9c3eae4a01",
-                "sha256:44dde0356def1d9345908c8f58dc604a434f2fe61c49ac13fac6e2da2ae429de"
+                "sha256:31fdb4bd45ebcd98eeda01e2c38fb391eae8a8480bdddbebb6cfd088486948a7",
+                "sha256:a0ad5f22faad3273ed87134853feeaad13e3d9221961ba6dc1198e2d57854e67"
             ],
-            "version": "==0.2.0"
+            "version": "==0.4.1"
         },
         "nbconvert": {
             "hashes": [
-                "sha256:4b2eff78c254a85d1668af70fca1cab4cecb077324ca72a1ac8959af08e78e3d",
-                "sha256:b327e1e75673fa4e76659396a0a012cb144bf3adc7aba3b55756de9497a2215e"
+                "sha256:0d6313199cd9560e198ac35fe5f74fd773441d1406280674dca60c3c6709512d",
+                "sha256:1fe9c484bddee508ddc1daeb37e594fe3b80d4cc0f6bd5acc2d4d8fd0a2eea23"
             ],
-            "version": "==6.0.0a1"
+            "version": "==6.0.0a4"
         },
         "nbformat": {
             "hashes": [
-                "sha256:65a79936a128fd85aef392b7fea520166364037118b6fe3ed52de742d06c4558",
-                "sha256:f0c47cf93c505cb943e2f131ef32b8ae869292b5f9f279db2bafb35867923f69"
+                "sha256:54d4d6354835a936bad7e8182dcd003ca3dc0cedfee5a306090e04854343b340",
+                "sha256:ea55c9b817855e2dfcd3f66d74857342612a60b1f09653440f4a5845e6e3523f"
             ],
-            "version": "==5.0.5"
+            "version": "==5.0.7"
         },
         "nbsphinx": {
             "hashes": [
-                "sha256:bc8ce94b00622e2d8fff61338c68734bf0d68dec844b70a8317e6fad7e619783",
-                "sha256:cf44b8675596fea7320f460f676fee26c8b3ee91140f80e41a77a46272af0081"
+                "sha256:560b23ff8468643b49e19293c154c93c6ee7090786922731e1c391bd566aac86",
+                "sha256:f50bd750e4ee3a4e4c3cf571155eab413dc87d581c1380021e7623205b5fa648"
             ],
             "index": "pypi",
-            "version": "==0.6.0"
+            "version": "==0.7.1"
         },
         "nest-asyncio": {
             "hashes": [
-                "sha256:14e194b72144052a82173ca9109bd07c57813a320f42c7acfad1e4d329988350",
-                "sha256:b4cdd08655e2848098d204a26590cbfa39fcbc4ad1811c568678ffc8a0c8e279"
+                "sha256:75dad56eaa7078e2e29c6630f114077fc5060069658d74545b0409e63ca8a028",
+                "sha256:766ee832cdef108497a70dd729cc4ff56d16a8d3e08404ae138bdf15913f66f9"
             ],
-            "version": "==1.3.2"
+            "version": "==1.3.3"
         },
         "notebook": {
             "hashes": [
-                "sha256:3edc616c684214292994a3af05eaea4cc043f6b4247d830f3a2f209fa7639a80",
-                "sha256:47a9092975c9e7965ada00b9a20f0cf637d001db60d241d479f53c0be117ad48"
+                "sha256:162747997b118ab302efb8e8e60e0c1fac4b9cdd74ebef5d9829294ed873de9a",
+                "sha256:26ec53ac302735bc650eb112cc90ec73ce29dd38da0c61b5c1da4ab1dc0d96a7"
             ],
-            "version": "==6.0.3"
+            "version": "==6.1.0rc1"
         },
         "numpy": {
             "hashes": [
-                "sha256:1598a6de323508cfeed6b7cd6c4efb43324f4692e20d1f76e1feec7f59013448",
-                "sha256:1b0ece94018ae21163d1f651b527156e1f03943b986188dd81bc7e066eae9d1c",
-                "sha256:2e40be731ad618cb4974d5ba60d373cdf4f1b8dcbf1dcf4d9dff5e212baf69c5",
-                "sha256:4ba59db1fcc27ea31368af524dcf874d9277f21fd2e1f7f1e2e0c75ee61419ed",
-                "sha256:59ca9c6592da581a03d42cc4e270732552243dc45e87248aa8d636d53812f6a5",
-                "sha256:5e0feb76849ca3e83dd396254e47c7dba65b3fa9ed3df67c2556293ae3e16de3",
-                "sha256:6d205249a0293e62bbb3898c4c2e1ff8a22f98375a34775a259a0523111a8f6c",
-                "sha256:6fcc5a3990e269f86d388f165a089259893851437b904f422d301cdce4ff25c8",
-                "sha256:82847f2765835c8e5308f136bc34018d09b49037ec23ecc42b246424c767056b",
-                "sha256:87902e5c03355335fc5992a74ba0247a70d937f326d852fc613b7f53516c0963",
-                "sha256:9ab21d1cb156a620d3999dd92f7d1c86824c622873841d6b080ca5495fa10fef",
-                "sha256:a1baa1dc8ecd88fb2d2a651671a84b9938461e8a8eed13e2f0a812a94084d1fa",
-                "sha256:a244f7af80dacf21054386539699ce29bcc64796ed9850c99a34b41305630286",
-                "sha256:a35af656a7ba1d3decdd4fae5322b87277de8ac98b7d9da657d9e212ece76a61",
-                "sha256:b1fe1a6f3a6f355f6c29789b5927f8bd4f134a4bd9a781099a7c4f66af8850f5",
-                "sha256:b5ad0adb51b2dee7d0ee75a69e9871e2ddfb061c73ea8bc439376298141f77f5",
-                "sha256:ba3c7a2814ec8a176bb71f91478293d633c08582119e713a0c5351c0f77698da",
-                "sha256:cd77d58fb2acf57c1d1ee2835567cd70e6f1835e32090538f17f8a3a99e5e34b",
-                "sha256:cdb3a70285e8220875e4d2bc394e49b4988bdb1298ffa4e0bd81b2f613be397c",
-                "sha256:deb529c40c3f1e38d53d5ae6cd077c21f1d49e13afc7936f7f868455e16b64a0",
-                "sha256:e7894793e6e8540dbeac77c87b489e331947813511108ae097f1715c018b8f3d"
+                "sha256:13af0184177469192d80db9bd02619f6fa8b922f9f327e077d6f2a6acb1ce1c0",
+                "sha256:26a45798ca2a4e168d00de75d4a524abf5907949231512f372b217ede3429e98",
+                "sha256:26f509450db547e4dfa3ec739419b31edad646d21fb8d0ed0734188b35ff6b27",
+                "sha256:30a59fb41bb6b8c465ab50d60a1b298d1cd7b85274e71f38af5a75d6c475d2d2",
+                "sha256:33c623ef9ca5e19e05991f127c1be5aeb1ab5cdf30cb1c5cf3960752e58b599b",
+                "sha256:356f96c9fbec59974a592452ab6a036cd6f180822a60b529a975c9467fcd5f23",
+                "sha256:3c40c827d36c6d1c3cf413694d7dc843d50997ebffbc7c87d888a203ed6403a7",
+                "sha256:4d054f013a1983551254e2379385e359884e5af105e3efe00418977d02f634a7",
+                "sha256:63d971bb211ad3ca37b2adecdd5365f40f3b741a455beecba70fd0dde8b2a4cb",
+                "sha256:658624a11f6e1c252b2cd170d94bf28c8f9410acab9f2fd4369e11e1cd4e1aaf",
+                "sha256:76766cc80d6128750075378d3bb7812cf146415bd29b588616f72c943c00d598",
+                "sha256:7b57f26e5e6ee2f14f960db46bd58ffdca25ca06dd997729b1b179fddd35f5a3",
+                "sha256:7b852817800eb02e109ae4a9cef2beda8dd50d98b76b6cfb7b5c0099d27b52d4",
+                "sha256:8cde829f14bd38f6da7b2954be0f2837043e8b8d7a9110ec5e318ae6bf706610",
+                "sha256:a2e3a39f43f0ce95204beb8fe0831199542ccab1e0c6e486a0b4947256215632",
+                "sha256:a86c962e211f37edd61d6e11bb4df7eddc4a519a38a856e20a6498c319efa6b0",
+                "sha256:a8705c5073fe3fcc297fb8e0b31aa794e05af6a329e81b7ca4ffecab7f2b95ef",
+                "sha256:b6aaeadf1e4866ca0fdf7bb4eed25e521ae21a7947c59f78154b24fc7abbe1dd",
+                "sha256:be62aeff8f2f054eff7725f502f6228298891fd648dc2630e03e44bf63e8cee0",
+                "sha256:c2edbb783c841e36ca0fa159f0ae97a88ce8137fb3a6cd82eae77349ba4b607b",
+                "sha256:cbe326f6d364375a8e5a8ccb7e9cd73f4b2f6dc3b2ed205633a0db8243e2a96a",
+                "sha256:d34fbb98ad0d6b563b95de852a284074514331e6b9da0a9fc894fb1cdae7a79e",
+                "sha256:d97a86937cf9970453c3b62abb55a6475f173347b4cde7f8dcdb48c8e1b9952d",
+                "sha256:dd53d7c4a69e766e4900f29db5872f5824a06827d594427cf1a4aa542818b796",
+                "sha256:df1889701e2dfd8ba4dc9b1a010f0a60950077fb5242bb92c8b5c7f1a6f2668a",
+                "sha256:fa1fe75b4a9e18b66ae7f0b122543c42debcf800aaafa0212aaff3ad273c2596"
             ],
             "index": "pypi",
-            "version": "==1.18.2"
+            "version": "==1.19.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
-                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
-            "version": "==20.3"
+            "version": "==20.4"
         },
         "pandas": {
             "hashes": [
-                "sha256:07c1b58936b80eafdfe694ce964ac21567b80a48d972879a359b3ebb2ea76835",
-                "sha256:0ebe327fb088df4d06145227a4aa0998e4f80a9e6aed4b61c1f303bdfdf7c722",
-                "sha256:11c7cb654cd3a0e9c54d81761b5920cdc86b373510d829461d8f2ed6d5905266",
-                "sha256:12f492dd840e9db1688126216706aa2d1fcd3f4df68a195f9479272d50054645",
-                "sha256:167a1315367cea6ec6a5e11e791d9604f8e03f95b57ad227409de35cf850c9c5",
-                "sha256:1a7c56f1df8d5ad8571fa251b864231f26b47b59cbe41aa5c0983d17dbb7a8e4",
-                "sha256:1fa4bae1a6784aa550a1c9e168422798104a85bf9c77a1063ea77ee6f8452e3a",
-                "sha256:32f42e322fb903d0e189a4c10b75ba70d90958cc4f66a1781ed027f1a1d14586",
-                "sha256:387dc7b3c0424327fe3218f81e05fc27832772a5dffbed385013161be58df90b",
-                "sha256:6597df07ea361231e60c00692d8a8099b519ed741c04e65821e632bc9ccb924c",
-                "sha256:743bba36e99d4440403beb45a6f4f3a667c090c00394c176092b0b910666189b",
-                "sha256:858a0d890d957ae62338624e4aeaf1de436dba2c2c0772570a686eaca8b4fc85",
-                "sha256:863c3e4b7ae550749a0bb77fa22e601a36df9d2905afef34a6965bed092ba9e5",
-                "sha256:a210c91a02ec5ff05617a298ad6f137b9f6f5771bf31f2d6b6367d7f71486639",
-                "sha256:ca84a44cf727f211752e91eab2d1c6c1ab0f0540d5636a8382a3af428542826e",
-                "sha256:d234bcf669e8b4d6cbcd99e3ce7a8918414520aeb113e2a81aeb02d0a533d7f7"
+                "sha256:02f1e8f71cd994ed7fcb9a35b6ddddeb4314822a0e09a9c5b2d278f8cb5d4096",
+                "sha256:13f75fb18486759da3ff40f5345d9dd20e7d78f2a39c5884d013456cec9876f0",
+                "sha256:35b670b0abcfed7cad76f2834041dcf7ae47fd9b22b63622d67cdc933d79f453",
+                "sha256:4c73f373b0800eb3062ffd13d4a7a2a6d522792fa6eb204d67a4fad0a40f03dc",
+                "sha256:5759edf0b686b6f25a5d4a447ea588983a33afc8a0081a0954184a4a87fd0dd7",
+                "sha256:5a7cf6044467c1356b2b49ef69e50bf4d231e773c3ca0558807cdba56b76820b",
+                "sha256:69c5d920a0b2a9838e677f78f4dde506b95ea8e4d30da25859db6469ded84fa8",
+                "sha256:8778a5cc5a8437a561e3276b85367412e10ae9fff07db1eed986e427d9a674f8",
+                "sha256:9871ef5ee17f388f1cb35f76dc6106d40cb8165c562d573470672f4cdefa59ef",
+                "sha256:9c31d52f1a7dd2bb4681d9f62646c7aa554f19e8e9addc17e8b1b20011d7522d",
+                "sha256:ab8173a8efe5418bbe50e43f321994ac6673afc5c7c4839014cf6401bbdd0705",
+                "sha256:ae961f1f0e270f1e4e2273f6a539b2ea33248e0e3a11ffb479d757918a5e03a9",
+                "sha256:b3c4f93fcb6e97d993bf87cdd917883b7dab7d20c627699f360a8fb49e9e0b91",
+                "sha256:c9410ce8a3dee77653bc0684cfa1535a7f9c291663bd7ad79e39f5ab58f67ab3",
+                "sha256:f69e0f7b7c09f1f612b1f8f59e2df72faa8a6b41c5a436dde5b615aaf948f107",
+                "sha256:faa42a78d1350b02a7d2f0dbe3c80791cf785663d6997891549d0f86dc49125e"
             ],
             "index": "pypi",
-            "version": "==1.0.3"
+            "version": "==1.0.5"
         },
         "pandocfilters": {
             "hashes": [
@@ -404,18 +449,17 @@
         },
         "parso": {
             "hashes": [
-                "sha256:0c5659e0c6eba20636f99a04f469798dca8da279645ce5c387315b2c23912157",
-                "sha256:8515fc12cfca6ee3aa59138741fc5624d62340c97e401c74875769948d4f2995"
+                "sha256:158c140fc04112dc45bca311633ae5033c2c2a7b732fa33d0955bad8152a8dd0",
+                "sha256:908e9fae2144a076d72ae4e25539143d40b8e3eafbaeae03c1bfe226f4cdf12c"
             ],
-            "version": "==0.6.2"
+            "version": "==0.7.0"
         },
-        "pexpect": {
+        "pathspec": {
             "hashes": [
-                "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
-                "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
+                "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0",
+                "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"
             ],
-            "markers": "sys_platform != 'win32'",
-            "version": "==4.8.0"
+            "version": "==0.8.0"
         },
         "pickleshare": {
             "hashes": [
@@ -424,11 +468,43 @@
             ],
             "version": "==0.7.5"
         },
+        "pillow": {
+            "hashes": [
+                "sha256:0295442429645fa16d05bd567ef5cff178482439c9aad0411d3f0ce9b88b3a6f",
+                "sha256:06aba4169e78c439d528fdeb34762c3b61a70813527a2c57f0540541e9f433a8",
+                "sha256:09d7f9e64289cb40c2c8d7ad674b2ed6105f55dc3b09aa8e4918e20a0311e7ad",
+                "sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f",
+                "sha256:1ca594126d3c4def54babee699c055a913efb01e106c309fa6b04405d474d5ae",
+                "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d",
+                "sha256:431b15cffbf949e89df2f7b48528be18b78bfa5177cb3036284a5508159492b5",
+                "sha256:52125833b070791fcb5710fabc640fc1df07d087fc0c0f02d3661f76c23c5b8b",
+                "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8",
+                "sha256:612cfda94e9c8346f239bf1a4b082fdd5c8143cf82d685ba2dba76e7adeeb233",
+                "sha256:6d7741e65835716ceea0fd13a7d0192961212fd59e741a46bbed7a473c634ed6",
+                "sha256:6edb5446f44d901e8683ffb25ebdfc26988ee813da3bf91e12252b57ac163727",
+                "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f",
+                "sha256:8dad18b69f710bf3a001d2bf3afab7c432785d94fcf819c16b5207b1cfd17d38",
+                "sha256:94cf49723928eb6070a892cb39d6c156f7b5a2db4e8971cb958f7b6b104fb4c4",
+                "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626",
+                "sha256:9ad7f865eebde135d526bb3163d0b23ffff365cf87e767c649550964ad72785d",
+                "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6",
+                "sha256:c79f9c5fb846285f943aafeafda3358992d64f0ef58566e23484132ecd8d7d63",
+                "sha256:c92302a33138409e8f1ad16731568c55c9053eee71bb05b6b744067e1b62380f",
+                "sha256:d08b23fdb388c0715990cbc06866db554e1822c4bdcf6d4166cf30ac82df8c41",
+                "sha256:d350f0f2c2421e65fbc62690f26b59b0bcda1b614beb318c81e38647e0f673a1",
+                "sha256:ec29604081f10f16a7aea809ad42e27764188fc258b02259a03a8ff7ded3808d",
+                "sha256:edf31f1150778abd4322444c393ab9c7bd2af271dd4dafb4208fb613b1f3cdc9",
+                "sha256:f7e30c27477dffc3e85c2463b3e649f751789e0f6c8456099eea7ddd53be4a8a",
+                "sha256:ffe538682dc19cc542ae7c3e504fdf54ca7f86fb8a135e59dd6bc8627eae6cce"
+            ],
+            "version": "==7.2.0"
+        },
         "prometheus-client": {
             "hashes": [
-                "sha256:71cd24a2b3eb335cb800c7159f423df1bd4dcd5171b234be15e3f31ec9f622da"
+                "sha256:983c7ac4b47478720db338f1491ef67a100b474e3bc7dafcbaefb7d0b8f9b01c",
+                "sha256:c6e6b706833a6bd1fd51711299edee907857be10ece535126a158f911ee80915"
             ],
-            "version": "==0.7.1"
+            "version": "==0.8.0"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -436,14 +512,6 @@
                 "sha256:df7e9e63aea609b1da3a65641ceaf5bc7d05e0a04de5bd45d05dbeffbabf9e04"
             ],
             "version": "==3.0.5"
-        },
-        "ptyprocess": {
-            "hashes": [
-                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
-                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
-            ],
-            "markers": "os_name != 'nt'",
-            "version": "==0.6.0"
         },
         "pygments": {
             "hashes": [
@@ -454,10 +522,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
-                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
+                "sha256:1060635ca5ac864c2b7bc7b05a448df4e32d7d8c65e33cbe1514810d339672a2",
+                "sha256:56a551039101858c9e189ac9e66e330a03fb7079e97ba6b50193643905f450ce"
             ],
-            "version": "==3.0.0a1"
+            "version": "==3.0.0a2"
         },
         "pyrsistent": {
             "hashes": [
@@ -474,50 +542,84 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
-                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
+                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
             ],
-            "version": "==2019.3"
+            "version": "==2020.1"
+        },
+        "pywin32": {
+            "hashes": [
+                "sha256:00eaf43dbd05ba6a9b0080c77e161e0b7a601f9a3f660727a952e40140537de7",
+                "sha256:11cb6610efc2f078c9e6d8f5d0f957620c333f4b23466931a247fb945ed35e89",
+                "sha256:1f45db18af5d36195447b2cffacd182fe2d296849ba0aecdab24d3852fbf3f80",
+                "sha256:37dc9935f6a383cc744315ae0c2882ba1768d9b06700a70f35dc1ce73cd4ba9c",
+                "sha256:6e38c44097a834a4707c1b63efa9c2435f5a42afabff634a17f563bc478dfcc8",
+                "sha256:8319bafdcd90b7202c50d6014efdfe4fde9311b3ff15fd6f893a45c0868de203",
+                "sha256:9b3466083f8271e1a5eb0329f4e0d61925d46b40b195a33413e0905dccb285e8",
+                "sha256:a60d795c6590a5b6baeacd16c583d91cce8038f959bd80c53bd9a68f40130f2d",
+                "sha256:af40887b6fc200eafe4d7742c48417529a8702dcc1a60bf89eee152d1d11209f",
+                "sha256:ec16d44b49b5f34e99eb97cf270806fdc560dff6f84d281eb2fcb89a014a56a9",
+                "sha256:ed74b72d8059a6606f64842e7917aeee99159ebd6b8d6261c518d002837be298",
+                "sha256:fa6ba028909cfc64ce9e24bcf22f588b14871980d9787f1e2002c99af8f1850c"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==228"
+        },
+        "pywinpty": {
+            "hashes": [
+                "sha256:1e525a4de05e72016a7af27836d512db67d06a015aeaf2fa0180f8e6a039b3c2",
+                "sha256:2740eeeb59297593a0d3f762269b01d0285c1b829d6827445fcd348fb47f7e70",
+                "sha256:2d7e9c881638a72ffdca3f5417dd1563b60f603e1b43e5895674c2a1b01f95a0",
+                "sha256:33df97f79843b2b8b8bc5c7aaf54adec08cc1bae94ee99dfb1a93c7a67704d95",
+                "sha256:5fb2c6c6819491b216f78acc2c521b9df21e0f53b9a399d58a5c151a3c4e2a2d",
+                "sha256:8fc5019ff3efb4f13708bd3b5ad327589c1a554cb516d792527361525a7cb78c",
+                "sha256:b358cb552c0f6baf790de375fab96524a0498c9df83489b8c23f7f08795e966b",
+                "sha256:dbd838de92de1d4ebf0dce9d4d5e4fc38d0b7b1de837947a18b57a882f219139",
+                "sha256:dd22c8efacf600730abe4a46c1388355ce0d4ab75dc79b15d23a7bd87bf05b48",
+                "sha256:e854211df55d107f0edfda8a80b39dfc87015bef52a8fe6594eb379240d81df2"
+            ],
+            "markers": "os_name == 'nt'",
+            "version": "==0.5.7"
         },
         "pyzmq": {
             "hashes": [
-                "sha256:0bbc1728fe4314b4ca46249c33873a390559edac7c217ec7001b5e0c34a8fb7f",
-                "sha256:1e076ad5bd3638a18c376544d32e0af986ca10d43d4ce5a5d889a8649f0d0a3d",
-                "sha256:242d949eb6b10197cda1d1cec377deab1d5324983d77e0d0bf9dc5eb6d71a6b4",
-                "sha256:26f4ae420977d2a8792d7c2d7bda43128b037b5eeb21c81951a94054ad8b8843",
-                "sha256:32234c21c5e0a767c754181c8112092b3ddd2e2a36c3f76fc231ced817aeee47",
-                "sha256:3f12ce1e9cc9c31497bd82b207e8e86ccda9eebd8c9f95053aae46d15ccd2196",
-                "sha256:4557d5e036e6d85715b4b9fdb482081398da1d43dc580d03db642b91605b409f",
-                "sha256:4f562dab21c03c7aa061f63b147a595dbe1006bf4f03213272fc9f7d5baec791",
-                "sha256:5e071b834051e9ecb224915398f474bfad802c2fff883f118ff5363ca4ae3edf",
-                "sha256:5e1f65e576ab07aed83f444e201d86deb01cd27dcf3f37c727bc8729246a60a8",
-                "sha256:5f10a31f288bf055be76c57710807a8f0efdb2b82be6c2a2b8f9a61f33a40cea",
-                "sha256:6aaaf90b420dc40d9a0e1996b82c6a0ff91d9680bebe2135e67c9e6d197c0a53",
-                "sha256:75238d3c16cab96947705d5709187a49ebb844f54354cdf0814d195dd4c045de",
-                "sha256:7f7e7b24b1d392bb5947ba91c981e7d1a43293113642e0d8870706c8e70cdc71",
-                "sha256:84b91153102c4bcf5d0f57d1a66a0f03c31e9e6525a5f656f52fc615a675c748",
-                "sha256:944f6bb5c63140d76494467444fd92bebd8674236837480a3c75b01fe17df1ab",
-                "sha256:a1f957c20c9f51d43903881399b078cddcf710d34a2950e88bce4e494dcaa4d1",
-                "sha256:a49fd42a29c1cc1aa9f461c5f2f5e0303adba7c945138b35ee7f4ab675b9f754",
-                "sha256:a99ae601b4f6917985e9bb071549e30b6f93c72f5060853e197bdc4b7d357e5f",
-                "sha256:ad48865a29efa8a0cecf266432ea7bc34e319954e55cf104be0319c177e6c8f5",
-                "sha256:b08e425cf93b4e018ab21dc8fdbc25d7d0502a23cc4fea2380010cf8cf11e462",
-                "sha256:bb10361293d96aa92be6261fa4d15476bca56203b3a11c62c61bd14df0ef89ba",
-                "sha256:bd1a769d65257a7a12e2613070ca8155ee348aa9183f2aadf1c8b8552a5510f5",
-                "sha256:cb3b7156ef6b1a119e68fbe3a54e0a0c40ecacc6b7838d57dd708c90b62a06dc",
-                "sha256:e8e4efb52ec2df8d046395ca4c84ae0056cf507b2f713ec803c65a8102d010de",
-                "sha256:f37c29da2a5b0c5e31e6f8aab885625ea76c807082f70b2d334d3fd573c3100a",
-                "sha256:f4d558bc5668d2345773a9ff8c39e2462dafcb1f6772a2e582fbced389ce527f",
-                "sha256:f5b6d015587a1d6f582ba03b226a9ddb1dfb09878b3be04ef48b01b7d4eb6b2a"
+                "sha256:07fb8fe6826a229dada876956590135871de60dbc7de5a18c3bcce2ed1f03c98",
+                "sha256:13a5638ab24d628a6ade8f794195e1a1acd573496c3b85af2f1183603b7bf5e0",
+                "sha256:15b4cb21118f4589c4db8be4ac12b21c8b4d0d42b3ee435d47f686c32fe2e91f",
+                "sha256:21f7d91f3536f480cb2c10d0756bfa717927090b7fb863e6323f766e5461ee1c",
+                "sha256:2a88b8fabd9cc35bd59194a7723f3122166811ece8b74018147a4ed8489e6421",
+                "sha256:342fb8a1dddc569bc361387782e8088071593e7eaf3e3ecf7d6bd4976edff112",
+                "sha256:4ee0bfd82077a3ff11c985369529b12853a4064320523f8e5079b630f9551448",
+                "sha256:54aa24fd60c4262286fc64ca632f9e747c7cc3a3a1144827490e1dc9b8a3a960",
+                "sha256:58688a2dfa044fad608a8e70ba8d019d0b872ec2acd75b7b5e37da8905605891",
+                "sha256:5b99c2ae8089ef50223c28bac57510c163bfdff158c9e90764f812b94e69a0e6",
+                "sha256:5b9d21fc56c8aacd2e6d14738021a9d64f3f69b30578a99325a728e38a349f85",
+                "sha256:5f1f2eb22aab606f808163eb1d537ac9a0ba4283fbeb7a62eb48d9103cf015c2",
+                "sha256:6ca519309703e95d55965735a667809bbb65f52beda2fdb6312385d3e7a6d234",
+                "sha256:87c78f6936e2654397ca2979c1d323ee4a889eef536cc77a938c6b5be33351a7",
+                "sha256:8952f6ba6ae598e792703f3134af5a01af8f5c7cf07e9a148f05a12b02412cea",
+                "sha256:931339ac2000d12fe212e64f98ce291e81a7ec6c73b125f17cf08415b753c087",
+                "sha256:956775444d01331c7eb412c5fb9bb62130dfaac77e09f32764ea1865234e2ca9",
+                "sha256:97b6255ae77328d0e80593681826a0479cb7bac0ba8251b4dd882f5145a2293a",
+                "sha256:aaa8b40b676576fd7806839a5de8e6d5d1b74981e6376d862af6c117af2a3c10",
+                "sha256:af0c02cf49f4f9eedf38edb4f3b6bb621d83026e7e5d76eb5526cc5333782fd6",
+                "sha256:b08780e3a55215873b3b8e6e7ca8987f14c902a24b6ac081b344fd430d6ca7cd",
+                "sha256:ba6f24431b569aec674ede49cad197cad59571c12deed6ad8e3c596da8288217",
+                "sha256:bafd651b557dd81d89bd5f9c678872f3e7b7255c1c751b78d520df2caac80230",
+                "sha256:bfff5ffff051f5aa47ba3b379d87bd051c3196b0c8a603e8b7ed68a6b4f217ec",
+                "sha256:cf5d689ba9513b9753959164cf500079383bc18859f58bf8ce06d8d4bef2b054",
+                "sha256:dcbc3f30c11c60d709c30a213dc56e88ac016fe76ac6768e64717bd976072566",
+                "sha256:f9d7e742fb0196992477415bb34366c12e9bb9a0699b8b3f221ff93b213d7bec",
+                "sha256:faee2604f279d31312bc455f3d024f160b6168b9c1dde22bf62d8c88a4deca8e"
             ],
-            "version": "==19.0.0"
+            "version": "==19.0.1"
         },
         "qtconsole": {
             "hashes": [
-                "sha256:1eb76ca095f22aa8f0137e8672a63422bfa22bd9a202b64240c5de64103470c9",
-                "sha256:d7834598825169fc322390fdfd96bf791833ded21bf22803f083662edbbf3d75"
+                "sha256:4f43d0b049eacb7d723772847f0c465feccce0ccb398871a6e146001a22bad23",
+                "sha256:f5cb275d30fc8085e2d1d18bc363e5ba0ce6e559bf37d7d6727b773134298754"
             ],
-            "version": "==4.7.2"
+            "version": "==4.7.5"
         },
         "qtpy": {
             "hashes": [
@@ -526,79 +628,95 @@
             ],
             "version": "==1.9.0"
         },
+        "regex": {
+            "hashes": [
+                "sha256:08997a37b221a3e27d68ffb601e45abfb0093d39ee770e4257bd2f5115e8cb0a",
+                "sha256:112e34adf95e45158c597feea65d06a8124898bdeac975c9087fe71b572bd938",
+                "sha256:1700419d8a18c26ff396b3b06ace315b5f2a6e780dad387e4c48717a12a22c29",
+                "sha256:2f6f211633ee8d3f7706953e9d3edc7ce63a1d6aad0be5dcee1ece127eea13ae",
+                "sha256:52e1b4bef02f4040b2fd547357a170fc1146e60ab310cdbdd098db86e929b387",
+                "sha256:55b4c25cbb3b29f8d5e63aeed27b49fa0f8476b0d4e1b3171d85db891938cc3a",
+                "sha256:5aaa5928b039ae440d775acea11d01e42ff26e1561c0ffcd3d805750973c6baf",
+                "sha256:654cb773b2792e50151f0e22be0f2b6e1c3a04c5328ff1d9d59c0398d37ef610",
+                "sha256:690f858d9a94d903cf5cada62ce069b5d93b313d7d05456dbcd99420856562d9",
+                "sha256:6ad8663c17db4c5ef438141f99e291c4d4edfeaacc0ce28b5bba2b0bf273d9b5",
+                "sha256:89cda1a5d3e33ec9e231ece7307afc101b5217523d55ef4dc7fb2abd6de71ba3",
+                "sha256:92d8a043a4241a710c1cf7593f5577fbb832cf6c3a00ff3fc1ff2052aff5dd89",
+                "sha256:95fa7726d073c87141f7bbfb04c284901f8328e2d430eeb71b8ffdd5742a5ded",
+                "sha256:97712e0d0af05febd8ab63d2ef0ab2d0cd9deddf4476f7aa153f76feef4b2754",
+                "sha256:b2ba0f78b3ef375114856cbdaa30559914d081c416b431f2437f83ce4f8b7f2f",
+                "sha256:bae83f2a56ab30d5353b47f9b2a33e4aac4de9401fb582b55c42b132a8ac3868",
+                "sha256:c78e66a922de1c95a208e4ec02e2e5cf0bb83a36ceececc10a72841e53fbf2bd",
+                "sha256:cf59bbf282b627130f5ba68b7fa3abdb96372b24b66bdf72a4920e8153fc7910",
+                "sha256:e3cdc9423808f7e1bb9c2e0bdb1c9dc37b0607b30d646ff6faf0d4e41ee8fee3",
+                "sha256:e9b64e609d37438f7d6e68c2546d2cb8062f3adb27e6336bc129b51be20773ac",
+                "sha256:fbff901c54c22425a5b809b914a3bfaf4b9570eee0e5ce8186ac71eb2025191c"
+            ],
+            "version": "==2020.6.8"
+        },
         "requests": {
             "hashes": [
-                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
-                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+                "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
+                "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
             ],
-            "version": "==2.23.0"
+            "version": "==2.24.0"
         },
         "scikit-learn": {
             "hashes": [
-                "sha256:1bf45e62799b6938357cfce19f72e3751448c4b27010e4f98553da669b5bbd86",
-                "sha256:267ad874b54c67b479c3b45eb132ef4a56ab2b27963410624a413a4e2a3fc388",
-                "sha256:2d1bb83d6c51a81193d8a6b5f31930e2959c0e1019d49bdd03f54163735dae4b",
-                "sha256:349ba3d837fb3f7cb2b91486c43713e4b7de17f9e852f165049b1b7ac2f81478",
-                "sha256:3f4d8eea3531d3eaf613fa33f711113dfff6021d57a49c9d319af4afb46f72f0",
-                "sha256:4990f0e166292d2a0f0ee528233723bcfd238bfdb3ec2512a9e27f5695362f35",
-                "sha256:57538d138ba54407d21e27c306735cbd42a6aae0df6a5a30c7a6edde46b0017d",
-                "sha256:5b722e8bb708f254af028dc2da86d23df5371cba57e24f889b672e7b15423caa",
-                "sha256:6043e2c4ccfc68328c331b0fc19691be8fb02bd76d694704843a23ad651de902",
-                "sha256:672ea38eb59b739a8907ec063642b486bcb5a2073dda5b72b7983eeaf1fd67c1",
-                "sha256:73207dca6e70f8f611f28add185cf3a793c8232a1722f21d82259560dc35cd50",
-                "sha256:83fc104a799cb340054e485c25dfeee712b36f5638fb374eba45a9db490f16ff",
-                "sha256:8416150ab505f1813da02cdbdd9f367b05bfc75cf251235015bb09f8674358a0",
-                "sha256:84e759a766c315deb5c85139ff879edbb0aabcddb9358acf499564ed1c21e337",
-                "sha256:8ed66ab27b3d68e57bb1f315fc35e595a5c4a1f108c3420943de4d18fc40e615",
-                "sha256:a7f8aa93f61aaad080b29a9018db93ded0586692c03ddf2122e47dd1d3a14e1b",
-                "sha256:ddd3bf82977908ff69303115dd5697606e669d8a7eafd7d83bb153ef9e11bd5e",
-                "sha256:de9933297f8659ee3bb330eafdd80d74cd73d5dab39a9026b65a4156bc479063",
-                "sha256:ea91a70a992ada395efc3d510cf011dc2d99dc9037bb38cd1cb00e14745005f5",
-                "sha256:eb4c9f0019abb374a2e55150f070a333c8f990b850d1eb4dfc2765fc317ffc7c",
-                "sha256:ffce8abfdcd459e72e5b91727b247b401b22253cbd18d251f842a60e26262d6f"
+                "sha256:04799686060ecbf8992f26a35be1d99e981894c8c7860c1365cda4200f954a16",
+                "sha256:058d213092de4384710137af1300ed0ff030b8c40459a6c6f73c31ccd274cc39",
+                "sha256:0c3464e46ef8bd4f1bfa5c009648c6449412c8f7e9b3fc0c9e3d800139c48827",
+                "sha256:0e7b55f73b35537ecd0d19df29dd39aa9e076dba78f3507b8136c819d84611fd",
+                "sha256:16feae4361be6b299d4d08df5a30956b4bfc8eadf173fe9258f6d59630f851d4",
+                "sha256:244ca85d6eba17a1e6e8a66ab2f584be6a7784b5f59297e3d7ff8c7983af627c",
+                "sha256:3e6e92b495eee193a8fa12a230c9b7976ea0fc1263719338e35c986ea1e42cff",
+                "sha256:5bcea4d6ee431c814261117281363208408aa4e665633655895feb059021aca6",
+                "sha256:93f56abd316d131645559ec0ab4f45e3391c2ccdd4eadaa4912f4c1e0a6f2c96",
+                "sha256:9e04c0811ea92931ee8490d638171b8cb2f21387efcfff526bbc8c2a3da60f1c",
+                "sha256:bded94236e16774385202cafd26190ce96db18e4dc21e99473848c61e4fdc400",
+                "sha256:c2fa33d20408b513cf432505c80e6eb4bf4d71434f1ae36680765d4a2c2a16ec",
+                "sha256:e3fec1c8831f8f93ad85581ca29ca1bb88e2da377fb097cf8322aa89c21bc9b8",
+                "sha256:e585682e37f2faa81ad6cd4472fff646bf2fd0542147bec93697a905db8e6bd2",
+                "sha256:e9879ba9e64ec3add41bf201e06034162f853652ef4849b361d73b0deb3153ad",
+                "sha256:ebe853e6f318f9d8b3b74dd17e553720d35646eff675a69eeaed12fbbbb07daa"
             ],
-            "version": "==0.22.2.post1"
+            "version": "==0.23.1"
         },
         "scipy": {
             "hashes": [
-                "sha256:00af72998a46c25bdb5824d2b729e7dabec0c765f9deb0b504f928591f5ff9d4",
-                "sha256:0902a620a381f101e184a958459b36d3ee50f5effd186db76e131cbefcbb96f7",
-                "sha256:1e3190466d669d658233e8a583b854f6386dd62d655539b77b3fa25bfb2abb70",
-                "sha256:2cce3f9847a1a51019e8c5b47620da93950e58ebc611f13e0d11f4980ca5fecb",
-                "sha256:3092857f36b690a321a662fe5496cb816a7f4eecd875e1d36793d92d3f884073",
-                "sha256:386086e2972ed2db17cebf88610aab7d7f6e2c0ca30042dc9a89cf18dcc363fa",
-                "sha256:71eb180f22c49066f25d6df16f8709f215723317cc951d99e54dc88020ea57be",
-                "sha256:770254a280d741dd3436919d47e35712fb081a6ff8bafc0f319382b954b77802",
-                "sha256:787cc50cab3020a865640aba3485e9fbd161d4d3b0d03a967df1a2881320512d",
-                "sha256:8a07760d5c7f3a92e440ad3aedcc98891e915ce857664282ae3c0220f3301eb6",
-                "sha256:8d3bc3993b8e4be7eade6dcc6fd59a412d96d3a33fa42b0fa45dc9e24495ede9",
-                "sha256:9508a7c628a165c2c835f2497837bf6ac80eb25291055f56c129df3c943cbaf8",
-                "sha256:a144811318853a23d32a07bc7fd5561ff0cac5da643d96ed94a4ffe967d89672",
-                "sha256:a1aae70d52d0b074d8121333bc807a485f9f1e6a69742010b33780df2e60cfe0",
-                "sha256:a2d6df9eb074af7f08866598e4ef068a2b310d98f87dc23bd1b90ec7bdcec802",
-                "sha256:bb517872058a1f087c4528e7429b4a44533a902644987e7b2fe35ecc223bc408",
-                "sha256:c5cac0c0387272ee0e789e94a570ac51deb01c796b37fb2aad1fb13f85e2f97d",
-                "sha256:cc971a82ea1170e677443108703a2ec9ff0f70752258d0e9f5433d00dda01f59",
-                "sha256:dba8306f6da99e37ea08c08fef6e274b5bf8567bb094d1dbe86a20e532aca088",
-                "sha256:dc60bb302f48acf6da8ca4444cfa17d52c63c5415302a9ee77b3b21618090521",
-                "sha256:dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59"
+                "sha256:039572f0ca9578a466683558c5bf1e65d442860ec6e13307d528749cfe6d07b8",
+                "sha256:058e84930407927f71963a4ad8c1dc96c4d2d075636a68578195648c81f78810",
+                "sha256:06b19a650471781056c1a2172eeeeb777b8b516e9434005dd392a4559e0938b9",
+                "sha256:35d042d6499caf1a5d171baed0ebf01eb665b7af2ad98a8ff1b0e6e783654540",
+                "sha256:57a0f2be3063dbe1e3daf31ec9005576e8fd1022a28159d0db71d14566899d16",
+                "sha256:5e0bb43ff581811ab7f27425f6b96c1ddf7591ccad2e486c9af0b910c18f7185",
+                "sha256:71742889393a724dfce755b6b61228677873d269a4234e51ddaf08b998433c91",
+                "sha256:7908c85854c5b5b6d3ce7fefafac1ca3e23ff9ac41edabc2d46ae5dc9fa070ac",
+                "sha256:81859ed3aad620752dd2c07c32b5d3a80a0d47c5e3813904621954a78a0ae899",
+                "sha256:8302d69fb1528ea7c7f2a1ea640d354c981b6eb8192d1c175349874209397604",
+                "sha256:9323d268775991b79690f7b9a28a4e8b8c4f2b160ed9f8a90123127314e2d3c1",
+                "sha256:b4858ccbd88f4b53950fb9fc0069c1d9fea83d7cff2382e1d8b023d3f4883014",
+                "sha256:c05c6fe76228cc13c5214e9faf5f2a871a1da54473bc417ab9da310d0e5fff8b",
+                "sha256:c06e731aa46c0dfc563cc636155758178ebc019ef78b9b0f4370effe2ac0f0e6",
+                "sha256:eb46d8b5947ca27b0bc972cecfba8130f088a83ab3d08c1a6033d9070b3046b3",
+                "sha256:fff15df01bef1243468be60c55178ed7576270b200aab08a7ffd5b8e0bbc340c"
             ],
             "index": "pypi",
-            "version": "==1.4.1"
+            "version": "==1.5.1"
         },
         "send2trash": {
             "hashes": [
-                "sha256:60001cc07d707fe247c94f74ca6ac0d3255aabcb930529690897ca2a39db28b2",
-                "sha256:f1691922577b6fa12821234aeb57599d887c4900b9ca537948d2dac34aea888b"
+                "sha256:522b8f5774aafc63d97703b357316220fff78ac7fcc004f37ef500fdb205892a",
+                "sha256:c9bd4195a93b5310149e06f246bd41dfdd13c67353fd767d6955af452d4ac16a"
             ],
-            "version": "==1.5.0"
+            "version": "==1.6.0b1"
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.14.0"
+            "version": "==1.15.0"
         },
         "sklearn": {
             "hashes": [
@@ -616,19 +734,19 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:50972d83b78990fd61d0d3fe8620814cae53db29443e92c13661bc43dff46ec8",
-                "sha256:8411878f4768ec2a8896b844d68070204f9354a831b37937989c2e559d29dffc"
+                "sha256:97dbf2e31fc5684bb805104b8ad34434ed70e6c588f6896991b2fdfd2bef8c00",
+                "sha256:b9daeb9b39aa1ffefc2809b43604109825300300b987a24f45976c001ba1a8fd"
             ],
             "index": "pypi",
-            "version": "==3.0.1"
+            "version": "==3.1.2"
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4",
-                "sha256:728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a"
+                "sha256:22c795ba2832a169ca301cd0a083f7a434e09c538c70beb42782c073651b707d",
+                "sha256:373413d0f82425aaa28fb288009bf0d0964711d347763af2f1b65cafcb028c82"
             ],
             "index": "pypi",
-            "version": "==0.4.3"
+            "version": "==0.5.0"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -686,13 +804,20 @@
             ],
             "version": "==0.4.4"
         },
+        "threadpoolctl": {
+            "hashes": [
+                "sha256:38b74ca20ff3bb42caca8b00055111d74159ee95c4370882bbff2b93d24da725",
+                "sha256:ddc57c96a38beb63db45d6c159b5ab07b6bced12c45a1f07b2b92f272aebfa6b"
+            ],
+            "version": "==2.1.0"
+        },
         "toml": {
             "hashes": [
-                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
-                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
             ],
             "index": "pypi",
-            "version": "==0.10.0"
+            "version": "==0.10.1"
         },
         "tornado": {
             "hashes": [
@@ -715,19 +840,45 @@
             ],
             "version": "==4.3.3"
         },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+            ],
+            "version": "==1.4.1"
+        },
         "urllib3": {
             "hashes": [
-                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
-                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
+                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
             ],
-            "version": "==1.25.8"
+            "version": "==1.25.9"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
-                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
+                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
+                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
             ],
-            "version": "==0.1.9"
+            "version": "==0.2.5"
         },
         "webencodings": {
             "hashes": [
@@ -754,17 +905,25 @@
     "develop": {
         "appdirs": {
             "hashes": [
-                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
-                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
             ],
-            "version": "==1.4.3"
+            "version": "==1.4.4"
         },
         "astroid": {
             "hashes": [
-                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
-                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
+                "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703",
+                "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"
             ],
-            "version": "==2.3.3"
+            "version": "==2.4.2"
+        },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
+                "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==1.4.0"
         },
         "attrs": {
             "hashes": [
@@ -778,23 +937,36 @@
                 "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
                 "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
             ],
-            "index": "pypi",
             "version": "==19.10b0"
         },
         "click": {
             "hashes": [
-                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
-                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "version": "==7.1.1"
+            "version": "==7.1.2"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
+                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.3"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
+                "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83",
+                "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
+            "version": "==1.7.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:aa0b40f50a00e72323cb5d41302f9c6165728fd764ac8822aa3fff00a40d56b4"
+            ],
+            "version": "==1.0.0"
         },
         "isort": {
             "hashes": [
@@ -838,17 +1010,17 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
-                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+                "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5",
+                "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"
             ],
-            "version": "==8.2.0"
+            "version": "==8.4.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
-                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
-            "version": "==20.3"
+            "version": "==20.4"
         },
         "pathspec": {
             "hashes": [
@@ -866,74 +1038,74 @@
         },
         "py": {
             "hashes": [
-                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
-                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
             ],
-            "version": "==1.8.1"
+            "version": "==1.9.0"
         },
         "pylint": {
             "hashes": [
-                "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
-                "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
+                "sha256:7dd78437f2d8d019717dbf287772d0b2dbdfd13fc016aa7faa08d67bccc46adc",
+                "sha256:d0ece7d223fe422088b0e8f13fa0a1e8eb745ebffcb8ed53d3e95394b6101a1c"
             ],
             "index": "pypi",
-            "version": "==2.4.4"
+            "version": "==2.5.3"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
-                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
+                "sha256:1060635ca5ac864c2b7bc7b05a448df4e32d7d8c65e33cbe1514810d339672a2",
+                "sha256:56a551039101858c9e189ac9e66e330a03fb7079e97ba6b50193643905f450ce"
             ],
-            "version": "==3.0.0a1"
+            "version": "==3.0.0a2"
         },
         "pytest": {
             "hashes": [
-                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
-                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+                "sha256:3296b4ad0b07363f69b740edf70e40db8286f882f019179b31e6a03d896afbff",
+                "sha256:c934e33079966229fd236ffae6a7a3c3415bd585693a646ba3adb62a2d695874"
             ],
             "index": "pypi",
-            "version": "==5.4.1"
+            "version": "==6.0.0rc1"
         },
         "regex": {
             "hashes": [
-                "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b",
-                "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8",
-                "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3",
-                "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e",
-                "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683",
-                "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1",
-                "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142",
-                "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3",
-                "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468",
-                "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e",
-                "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3",
-                "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a",
-                "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f",
-                "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6",
-                "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156",
-                "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b",
-                "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db",
-                "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd",
-                "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a",
-                "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948",
-                "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"
+                "sha256:08997a37b221a3e27d68ffb601e45abfb0093d39ee770e4257bd2f5115e8cb0a",
+                "sha256:112e34adf95e45158c597feea65d06a8124898bdeac975c9087fe71b572bd938",
+                "sha256:1700419d8a18c26ff396b3b06ace315b5f2a6e780dad387e4c48717a12a22c29",
+                "sha256:2f6f211633ee8d3f7706953e9d3edc7ce63a1d6aad0be5dcee1ece127eea13ae",
+                "sha256:52e1b4bef02f4040b2fd547357a170fc1146e60ab310cdbdd098db86e929b387",
+                "sha256:55b4c25cbb3b29f8d5e63aeed27b49fa0f8476b0d4e1b3171d85db891938cc3a",
+                "sha256:5aaa5928b039ae440d775acea11d01e42ff26e1561c0ffcd3d805750973c6baf",
+                "sha256:654cb773b2792e50151f0e22be0f2b6e1c3a04c5328ff1d9d59c0398d37ef610",
+                "sha256:690f858d9a94d903cf5cada62ce069b5d93b313d7d05456dbcd99420856562d9",
+                "sha256:6ad8663c17db4c5ef438141f99e291c4d4edfeaacc0ce28b5bba2b0bf273d9b5",
+                "sha256:89cda1a5d3e33ec9e231ece7307afc101b5217523d55ef4dc7fb2abd6de71ba3",
+                "sha256:92d8a043a4241a710c1cf7593f5577fbb832cf6c3a00ff3fc1ff2052aff5dd89",
+                "sha256:95fa7726d073c87141f7bbfb04c284901f8328e2d430eeb71b8ffdd5742a5ded",
+                "sha256:97712e0d0af05febd8ab63d2ef0ab2d0cd9deddf4476f7aa153f76feef4b2754",
+                "sha256:b2ba0f78b3ef375114856cbdaa30559914d081c416b431f2437f83ce4f8b7f2f",
+                "sha256:bae83f2a56ab30d5353b47f9b2a33e4aac4de9401fb582b55c42b132a8ac3868",
+                "sha256:c78e66a922de1c95a208e4ec02e2e5cf0bb83a36ceececc10a72841e53fbf2bd",
+                "sha256:cf59bbf282b627130f5ba68b7fa3abdb96372b24b66bdf72a4920e8153fc7910",
+                "sha256:e3cdc9423808f7e1bb9c2e0bdb1c9dc37b0607b30d646ff6faf0d4e41ee8fee3",
+                "sha256:e9b64e609d37438f7d6e68c2546d2cb8062f3adb27e6336bc129b51be20773ac",
+                "sha256:fbff901c54c22425a5b809b914a3bfaf4b9570eee0e5ce8186ac71eb2025191c"
             ],
-            "version": "==2020.4.4"
+            "version": "==2020.6.8"
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.14.0"
+            "version": "==1.15.0"
         },
         "toml": {
             "hashes": [
-                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
-                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
             ],
             "index": "pypi",
-            "version": "==0.10.0"
+            "version": "==0.10.1"
         },
         "typed-ast": {
             "hashes": [
@@ -959,21 +1131,13 @@
                 "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
                 "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
-            "markers": "implementation_name == 'cpython' and python_version < '3.8'",
             "version": "==1.4.1"
-        },
-        "wcwidth": {
-            "hashes": [
-                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
-                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
-            ],
-            "version": "==0.1.9"
         },
         "wrapt": {
             "hashes": [
-                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
             ],
-            "version": "==1.11.2"
+            "version": "==1.12.1"
         },
         "zipp": {
             "hashes": [

--- a/doc/tutorials/SIR-X.ipynb
+++ b/doc/tutorials/SIR-X.ipynb
@@ -29,10 +29,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Uncomment this cell to activate black code formatter in the notebook\n",
+    "# %load_ext nb_black"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Import packages\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "\n",
     "%matplotlib inline"
    ]
   },
@@ -87,14 +98,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "China = jhu_df[jhu_df[jhu_df.columns[1]]==\"China\"]\n",
+    "China = jhu_df[jhu_df[jhu_df.columns[1]] == \"China\"]\n",
     "city_name = \"Guangdong\"\n",
     "city = China[China[\"Province/State\"] == city_name]\n",
-    "city = city.drop(columns=[\"Province/State\", \"Country/Region\", \"Lat\",\"Long\"])\n",
+    "city = city.drop(columns=[\"Province/State\", \"Country/Region\", \"Lat\", \"Long\"])\n",
     "time_index = pd.to_datetime(city.columns)\n",
     "data = city.values\n",
     "# Visualize the time\n",
-    "ts = pd.Series(data = city.values[0], index = time_index)"
+    "ts = pd.Series(data=city.values[0], index=time_index)"
    ]
   },
   {
@@ -111,8 +122,8 @@
    "outputs": [],
    "source": [
     "ts.plot()\n",
-    "plt.title('Guangdong COVID-19 cases')\n",
-    "plt.ylabel('$C(t)$: Number of reported cases', size=12)\n",
+    "plt.title(\"Guangdong COVID-19 cases\")\n",
+    "plt.ylabel(\"$C(t)$: Number of reported cases\", size=12)\n",
     "plt.show()"
    ]
   },
@@ -131,12 +142,12 @@
    "source": [
     "ts_clean = ts.dropna()\n",
     "# Extract data\n",
-    "ts_fit = ts_clean['2020-01-21':\"2020-02-12\"]\n",
+    "ts_fit = ts_clean[\"2020-01-21\":\"2020-02-12\"]\n",
     "# Convert index to numeric\n",
     "ts_num = pd.to_numeric(ts_fit.index)\n",
     "t0 = ts_num[0]\n",
     "# Convert datetime to days\n",
-    "t_days = (ts_num-t0)/(10**9*86400)\n",
+    "t_days = (ts_num - t0) / (10 ** 9 * 86400)\n",
     "t_days = t_days.astype(int).values\n",
     "# t_days is an input for SIR"
    ]
@@ -148,8 +159,8 @@
    "outputs": [],
    "source": [
     "# Define the X number\n",
-    "nX = ts_fit.values # Number of infected\n",
-    "N = 104.3e6 # Population size of Guangdong"
+    "nX = ts_fit.values  # Number of infected\n",
+    "N = 104.3e6  # Population size of Guangdong"
    ]
   },
   {
@@ -165,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ts_fit.plot(style='ro')\n",
+    "ts_fit.plot(style=\"ro\")\n",
     "plt.xlabel(\"Number of infected\")\n",
     "plt.show()"
    ]
@@ -201,23 +212,25 @@
    "source": [
     "# These lines are required only if opensir wasn't installed using pip install, or if opensir is running in the pipenv virtual environment\n",
     "import sys\n",
-    "path_opensir = '../../'\n",
+    "\n",
+    "path_opensir = \"../../\"\n",
     "sys.path.append(path_opensir)\n",
     "\n",
     "# Import SIR and SIRX models\n",
     "from opensir.models import SIR, SIRX\n",
-    "nX = ts_fit.values # Number of observed infections of the time series\n",
-    "N = 104.3e6 # Population size of Guangdong\n",
+    "\n",
+    "nX = ts_fit.values  # Number of observed infections of the time series\n",
+    "N = 104.3e6  # Population size of Guangdong\n",
     "params = [0.95, 0.38]\n",
-    "w0 = (N-nX[0], nX[0], 0)\n",
+    "w0 = (N - nX[0], nX[0], 0)\n",
     "\n",
     "G_sir = SIR()\n",
     "G_sir.set_params(p=params, initial_conds=w0)\n",
-    "G_sir.fit_input=2\n",
+    "G_sir.fit_input = 2\n",
     "G_sir.fit(t_days, nX)\n",
-    "G_sir.solve(t_days[-1], t_days[-1]+1)\n",
-    "t_SIR = G_sir.fetch()[:,0]\n",
-    "I_SIR = G_sir.fetch()[:,2]"
+    "G_sir.solve(t_days[-1], t_days[-1] + 1)\n",
+    "t_SIR = G_sir.fetch()[:, 0]\n",
+    "I_SIR = G_sir.fetch()[:, 2]"
    ]
   },
   {
@@ -234,9 +247,9 @@
    "outputs": [],
    "source": [
     "ax = plt.axes()\n",
-    "ax.tick_params(axis=\"both\", which=\"major\", labelsize= 14 )\n",
+    "ax.tick_params(axis=\"both\", which=\"major\", labelsize=14)\n",
     "plt.plot(t_SIR, I_SIR)\n",
-    "plt.plot(t_days, nX, 'ro')\n",
+    "plt.plot(t_days, nX, \"ro\")\n",
     "plt.show()"
    ]
   },
@@ -261,19 +274,19 @@
    "outputs": [],
    "source": [
     "g_sirx = SIRX()\n",
-    "params = [6.2/8, 1/8, 0.05, 0.05, 5]\n",
+    "params = [6.2 / 8, 1 / 8, 0.05, 0.05, 5]\n",
     "# X_0 can be directly ontained from the statistics\n",
-    "n_x0 = nX[0]            # Number of people tested positive\n",
+    "n_x0 = nX[0]  # Number of people tested positive\n",
     "n_i0 = nX[0]\n",
     "\n",
-    "w0 = (N-n_x0-n_i0, n_i0, 0, n_x0)\n",
+    "w0 = (N - n_x0 - n_i0, n_i0, 0, n_x0)\n",
     "g_sirx.set_params(p=params, initial_conds=w0)\n",
     "# Fit all parameters\n",
-    "fit_index=[False, False, True, True, True]\n",
-    "g_sirx.fit(t_days, nX, fit_index = fit_index)\n",
-    "g_sirx.solve(t_days[-1], t_days[-1]+1)\n",
-    "t_sirx = g_sirx.fetch()[:,0]\n",
-    "inf_sirx = g_sirx.fetch()[:,4]"
+    "fit_index = [False, False, True, True, True]\n",
+    "g_sirx.fit(t_days, nX, fit_index=fit_index)\n",
+    "g_sirx.solve(t_days[-1], t_days[-1] + 1)\n",
+    "t_sirx = g_sirx.fetch()[:, 0]\n",
+    "inf_sirx = g_sirx.fetch()[:, 4]"
    ]
   },
   {
@@ -282,16 +295,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=[6,6])\n",
+    "plt.figure(figsize=[6, 6])\n",
     "ax = plt.axes()\n",
-    "plt.plot(t_sirx, inf_sirx, 'b-', linewidth=2)\n",
-    "plt.plot(t_SIR, I_SIR,'g-', linewidth=2)\n",
-    "plt.plot(t_days, nX, 'ro')\n",
-    "plt.legend([\"SIR-X model fit\", \"SIR model fit\", \"Number of reported cases\"], fontsize=13)\n",
+    "plt.plot(t_sirx, inf_sirx, \"b-\", linewidth=2)\n",
+    "plt.plot(t_SIR, I_SIR, \"g-\", linewidth=2)\n",
+    "plt.plot(t_days, nX, \"ro\")\n",
+    "plt.legend(\n",
+    "    [\"SIR-X model fit\", \"SIR model fit\", \"Number of reported cases\"], fontsize=13\n",
+    ")\n",
     "plt.title(\"SARS-CoV-2 evolution in Guangdong, China\", size=15)\n",
-    "plt.xlabel('Days', fontsize=14)\n",
-    "plt.ylabel('COVID-19 confirmed cases', fontsize=14)\n",
-    "ax.tick_params(axis='both', which='major', labelsize=14)\n",
+    "plt.xlabel(\"Days\", fontsize=14)\n",
+    "plt.ylabel(\"COVID-19 confirmed cases\", fontsize=14)\n",
+    "ax.tick_params(axis=\"both\", which=\"major\", labelsize=14)\n",
     "plt.show()"
    ]
   },
@@ -316,10 +331,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Effective infectious period T_I_eff =  %.2f days \" % g_sirx.t_inf_eff )\n",
-    "print(\"Effective reproduction rate R_0_eff =  %.2f, Maier and Brockmann = %.2f\" % (g_sirx.r0_eff, 3.02))\n",
-    "print(\"Public containment leverage =  %.2f, Maier and Brockmann = %.2f\" % (g_sirx.pcl, 0.75))\n",
-    "print(\"Quarantine probability =  %.2f, Maier and Brockmann = %.2f\" % (g_sirx.q_prob, 0.51))"
+    "print(\"Effective infectious period T_I_eff =  %.2f days \" % g_sirx.t_inf_eff)\n",
+    "print(\n",
+    "    \"Effective reproduction rate R_0_eff =  %.2f, Maier and Brockmann = %.2f\"\n",
+    "    % (g_sirx.r0_eff, 3.02)\n",
+    ")\n",
+    "print(\n",
+    "    \"Public containment leverage =  %.2f, Maier and Brockmann = %.2f\"\n",
+    "    % (g_sirx.pcl, 0.75)\n",
+    ")\n",
+    "print(\n",
+    "    \"Quarantine probability =  %.2f, Maier and Brockmann = %.2f\" % (g_sirx.q_prob, 0.51)\n",
+    ")"
    ]
   },
   {
@@ -338,7 +361,7 @@
     "# Make predictions and visualize\n",
     "# Obtain the results 14 days after the train data ends\n",
     "sirx_pred = g_sirx.predict(14)\n",
-    "print('T n_S \\t   n_I \\tn_R \\tn_X')\n",
+    "print(\"T n_S \\t   n_I \\tn_R \\tn_X\")\n",
     "for i in sirx_pred:\n",
     "    print(*i.astype(int))"
    ]
@@ -356,13 +379,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    " # Import datetime module from the standard library\n",
+    "# Import datetime module from the standard library\n",
     "import datetime\n",
+    "\n",
     "# Obtain the last day from the data used to train the model\n",
-    "last_time = ts_fit.index[-1] \n",
+    "last_time = ts_fit.index[-1]\n",
     "# Create a date time range based on the number of rows of the prediction\n",
-    "numdays = sirx_pred.shape[0] \n",
-    "day_zero = datetime.datetime(last_time.year,last_time.month,last_time.day)\n",
+    "numdays = sirx_pred.shape[0]\n",
+    "day_zero = datetime.datetime(last_time.year, last_time.month, last_time.day)\n",
     "date_list = [day_zero + datetime.timedelta(days=x) for x in range(numdays)]"
    ]
   },
@@ -380,11 +404,11 @@
    "outputs": [],
    "source": [
     "# Extract figure and axes\n",
-    "fig, ax = plt.subplots(figsize = [5,5])\n",
+    "fig, ax = plt.subplots(figsize=[5, 5])\n",
     "# Create core plot attributes\n",
-    "plt.plot(date_list, sirx_pred[:,4], color = 'red', linewidth =2)\n",
-    "plt.title('Prediction of Guangdong Cases', size=14)\n",
-    "plt.ylabel('Number of infected', size=14)\n",
+    "plt.plot(date_list, sirx_pred[:, 4], color=\"blue\", linewidth=2)\n",
+    "plt.title(\"Prediction of Guangdong Cases\", size=14)\n",
+    "plt.ylabel(\"Number of infected\", size=14)\n",
     "# Remove trailing space\n",
     "plt.xlim(date_list[0], date_list[-1])\n",
     "# Limit the amount of data displayed\n",
@@ -414,7 +438,7 @@
    "outputs": [],
    "source": [
     "# Calculate confidence intervals\n",
-    "mse_avg, mse_list, p_list, pred_data = g_sirx.block_cv(lags = 1, min_sample = 6)"
+    "mse_avg, mse_list, p_list, pred_data = g_sirx.block_cv(lags=1, min_sample=6)"
    ]
   },
   {
@@ -473,9 +497,9 @@
    "outputs": [],
    "source": [
     "# Predict\n",
-    "g_sirx.solve(t_days[-1]+1,t_days[-1]+2)\n",
-    "n_X_tplusone = g_sirx.fetch()[-1,4]\n",
-    "print(\"Estimation of n_X_{t+1} = %.0f +- %.0f \" % (n_X_tplusone, 2*mse_avg[0]) )"
+    "g_sirx.solve(t_days[-1] + 1, t_days[-1] + 2)\n",
+    "n_X_tplusone = g_sirx.fetch()[-1, 4]\n",
+    "print(\"Estimation of n_X_{t+1} = %.0f +- %.0f \" % (n_X_tplusone, 2 * mse_avg[0]))"
    ]
   },
   {
@@ -492,7 +516,7 @@
     "par_block_cv.columns = g_sirx.PARAMS\n",
     "# Add the day. Note that we take the days from min_sample until the end of the array, as days\n",
     "# 0,1,2 are used for the first sampling in the block cross-validation\n",
-    "par_block_cv['Day'] = t_days[5:]\n",
+    "par_block_cv[\"Day\"] = t_days[5:]\n",
     "# Explore formatted dataframe for parametric analysis\n",
     "par_block_cv.head(len(p_list))"
    ]
@@ -505,12 +529,12 @@
    },
    "outputs": [],
    "source": [
-    "plt.figure(figsize = [5,5])\n",
+    "plt.figure(figsize=[5, 5])\n",
     "ax = plt.axes()\n",
-    "ax.tick_params(axis = \"both\", which = \"major\", labelsize = 14 )\n",
-    "plt.plot(mse_list[0],'ro')\n",
-    "plt.xlabel('Number of days used to predict the next day', size = 14)\n",
-    "plt.ylabel('MSE', size = 14)\n",
+    "ax.tick_params(axis=\"both\", which=\"major\", labelsize=14)\n",
+    "plt.plot(mse_list[0], \"ro\")\n",
+    "plt.xlabel(\"Number of days used to predict the next day\", size=14)\n",
+    "plt.ylabel(\"MSE\", size=14)\n",
     "plt.show()"
    ]
   },
@@ -552,16 +576,16 @@
    "outputs": [],
    "source": [
     "# Predict\n",
-    "plt.figure(figsize=[6,6])\n",
+    "plt.figure(figsize=[6, 6])\n",
     "ax = plt.axes()\n",
-    "ax.tick_params(axis=\"both\", which=\"major\", labelsize= 14 )\n",
-    "g_sirx.solve(40,41)\n",
+    "ax.tick_params(axis=\"both\", which=\"major\", labelsize=14)\n",
+    "g_sirx.solve(40, 41)\n",
     "# Plot\n",
-    "plt.plot(g_sirx.fetch()[:,4], 'b-', linewidth=2) # X(t)\n",
-    "plt.plot(g_sirx.fetch()[:,2], 'b--', linewidth=2) # I(t)\n",
-    "plt.xlabel('Day', size=14)\n",
-    "plt.ylabel('Number of people', size=14)\n",
-    "plt.legend([\"X(t): Confirmed\",\"I(t) = Infected\"], fontsize=13)\n",
+    "plt.plot(g_sirx.fetch()[:, 4], \"b-\", linewidth=2)  # X(t)\n",
+    "plt.plot(g_sirx.fetch()[:, 2], \"b--\", linewidth=2)  # I(t)\n",
+    "plt.xlabel(\"Day\", size=14)\n",
+    "plt.ylabel(\"Number of people\", size=14)\n",
+    "plt.legend([\"X(t): Confirmed\", \"I(t) = Infected\"], fontsize=13)\n",
     "plt.title(city_name)\n",
     "plt.show()"
    ]

--- a/doc/tutorials/SIR.ipynb
+++ b/doc/tutorials/SIR.ipynb
@@ -56,10 +56,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np # Numerical computing\n",
-    "import matplotlib.pyplot as plt # Visualization\n",
-    "from scipy.integrate import odeint # ODE system numerical integrator\n",
-    "from scipy.optimize import curve_fit # Minimize squared errors using LM method"
+    "# Uncomment this cell for code formatting using nb_black\n",
+    "# %load_ext nb_black"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np  # Numerical computing\n",
+    "import matplotlib.pyplot as plt  # Visualization\n",
+    "from scipy.integrate import odeint  # ODE system numerical integrator\n",
+    "from scipy.optimize import curve_fit  # Minimize squared errors using LM method"
    ]
   },
   {
@@ -129,16 +139,18 @@
    "source": [
     "# Use Ealing as an example to determine model initial conditions\n",
     "# Input data must be np.array\n",
-    "Ealing_data = np.array([8, 18, 20, 28, 31, 42, 53, 54, 80, 97, 106, 123, 136, 165, 209, 241]) # N_of infected\n",
+    "Ealing_data = np.array(\n",
+    "    [8, 18, 20, 28, 31, 42, 53, 54, 80, 97, 106, 123, 136, 165, 209, 241]\n",
+    ")  # N_of infected\n",
     "\n",
-    "P_Ealing = 342000 # Ealing population ONS 2018 mid year\n",
-    "I_Ealing = 8      # Infected people at 14/03/2020\n",
-    "R_Ealing = 0      # Recovered people at 29/03/2020\n",
+    "P_Ealing = 342000  # Ealing population ONS 2018 mid year\n",
+    "I_Ealing = 8  # Infected people at 14/03/2020\n",
+    "R_Ealing = 0  # Recovered people at 29/03/2020\n",
     "n_days = len(Ealing_data)\n",
     "\n",
     "# Input parameters\n",
-    "beta = 0.38 # Per day\n",
-    "alpha = 2.5 * beta # WHO estimate"
+    "beta = 0.38  # Per day\n",
+    "alpha = 2.5 * beta  # WHO estimate"
    ]
   },
   {
@@ -155,9 +167,9 @@
    "outputs": [],
    "source": [
     "# Calculate initial conditions in terms of total number of individuals\n",
-    "S0 = (P_Ealing-I_Ealing)\n",
+    "S0 = P_Ealing - I_Ealing\n",
     "I0 = I_Ealing\n",
-    "R0 = R_Ealing    # Recovered people\n",
+    "R0 = R_Ealing  # Recovered people\n",
     "\n",
     "# Construct vector of parameters\n",
     "params = [alpha, beta]\n",
@@ -181,7 +193,8 @@
    "source": [
     "# These lines are required only if opensir wasn't installed using pip install, or if opensir is running in the pipenv virtual environment\n",
     "import sys\n",
-    "path_opensir = '../../'\n",
+    "\n",
+    "path_opensir = \"../../\"\n",
     "sys.path.append(path_opensir)\n",
     "\n",
     "# Import SIR and SIRX models\n",
@@ -197,24 +210,24 @@
     "# Initialize an emplty SIR model\n",
     "my_SIR = SIR()\n",
     "# Set model parameters\n",
-    "my_SIR.set_params(p=params,initial_conds=w0)\n",
+    "my_SIR.set_params(p=params, initial_conds=w0)\n",
     "\n",
     "# Call model.solve functions with the time in days and the number of points\n",
     "# as the number of days\n",
-    "my_SIR.solve(n_days-1, n_days)\n",
+    "my_SIR.solve(n_days - 1, n_days)\n",
     "# Unpack the numerical solution using the model.fetch() method\n",
     "sol = my_SIR.fetch()\n",
     "# Unpack the numerical solution for the susceptible (S), infected (I) and recovered or removed (R)\n",
-    "S_sir = sol[:,1]\n",
-    "I_sir = sol[:,2]\n",
-    "R_sir = sol[:,3]\n",
+    "S_sir = sol[:, 1]\n",
+    "I_sir = sol[:, 2]\n",
+    "R_sir = sol[:, 3]\n",
     "# Plot the results\n",
-    "# Define array of days. Note that the initial day is the day \"zero\", so \n",
+    "# Define array of days. Note that the initial day is the day \"zero\", so\n",
     "# the final day is the number of days minus one. This is divided in n_days\n",
     "# intervals to be consistent with the input\n",
-    "days_list = np.linspace(0, n_days-1, n_days)\n",
+    "days_list = np.linspace(0, n_days - 1, n_days)\n",
     "plt.plot(days_list, I_sir)\n",
-    "plt.plot(days_list, Ealing_data,'bo')\n",
+    "plt.plot(days_list, Ealing_data, \"bo\")\n",
     "plt.show()\n",
     "my_SIR.r0"
    ]
@@ -249,20 +262,20 @@
    "source": [
     "# Create SIR with default parameters\n",
     "my_SIR_fitted = SIR()\n",
-    "my_SIR_fitted.set_params(params,w0)\n",
+    "my_SIR_fitted.set_params(params, w0)\n",
     "\n",
     "# Fit parameters\n",
-    "w = my_SIR_fitted.fit(days_list, Ealing_data, fit_index=[True,False])\n",
+    "w = my_SIR_fitted.fit(days_list, Ealing_data, fit_index=[True, False])\n",
     "# Print the fitted reproduction rate\n",
     "print(\"Fitted reproduction rate R_0 = %.2f\" % my_SIR_fitted.r0)\n",
     "# Build the new solution\n",
-    "my_SIR_fitted.solve(n_days-1, n_days)\n",
+    "my_SIR_fitted.solve(n_days - 1, n_days)\n",
     "# Extract solution\n",
     "sol = my_SIR_fitted.fetch()\n",
     "# Plot the results\n",
     "\n",
-    "plt.plot(days_list,sol[:,2])\n",
-    "plt.plot(days_list,Ealing_data,'bo')\n",
+    "plt.plot(days_list, sol[:, 2])\n",
+    "plt.plot(days_list, Ealing_data, \"bo\")\n",
     "plt.show()"
    ]
   },
@@ -294,11 +307,11 @@
    "source": [
     "long_term_days = 90\n",
     "# Convert into seconds\n",
-    "tf_long = long_term_days-1\n",
+    "tf_long = long_term_days - 1\n",
     "sol_long = my_SIR_fitted.solve(tf_long, long_term_days).fetch()\n",
-    "N_S_long = sol_long[:,1]\n",
-    "N_I_long = sol_long[:,2]\n",
-    "N_R_long = sol_long[:,3]"
+    "N_S_long = sol_long[:, 1]\n",
+    "N_I_long = sol_long[:, 2]\n",
+    "N_R_long = sol_long[:, 3]"
    ]
   },
   {
@@ -308,21 +321,21 @@
    "outputs": [],
    "source": [
     "# Plot the number of susceptible, infected and recovered in a two months period\n",
-    "tspan_long = np.linspace(0,tf_long,long_term_days)\n",
-    "plt.figure(figsize=[15,5])\n",
-    "plt.subplot(1,3,1)\n",
-    "plt.plot(tspan_long,N_S_long)\n",
-    "plt.xlabel('Days')\n",
+    "tspan_long = np.linspace(0, tf_long, long_term_days)\n",
+    "plt.figure(figsize=[15, 5])\n",
+    "plt.subplot(1, 3, 1)\n",
+    "plt.plot(tspan_long, N_S_long)\n",
+    "plt.xlabel(\"Days\")\n",
     "plt.ylabel(\"Number of people\")\n",
     "plt.title(\"Susceptible\")\n",
-    "plt.subplot(1,3,2)\n",
-    "plt.plot(tspan_long,N_I_long)\n",
-    "plt.xlabel('Days')\n",
+    "plt.subplot(1, 3, 2)\n",
+    "plt.plot(tspan_long, N_I_long)\n",
+    "plt.xlabel(\"Days\")\n",
     "plt.title(\"Infected\")\n",
-    "plt.subplot(1,3,3)\n",
-    "plt.plot(tspan_long,N_R_long)\n",
+    "plt.subplot(1, 3, 3)\n",
+    "plt.plot(tspan_long, N_R_long)\n",
     "plt.title(\"Recovered or removed\")\n",
-    "plt.xlabel('Days')\n",
+    "plt.xlabel(\"Days\")\n",
     "plt.show()"
    ]
   },
@@ -365,14 +378,14 @@
     "    S_list = []\n",
     "    I_list = []\n",
     "    R_list = []\n",
-    "    \n",
+    "\n",
     "    for i in alpha_list:\n",
     "        # Update parameter list\n",
     "        model.p[0] = i\n",
-    "        wsol=model.solve(tf,numpoints).fetch()\n",
-    "        S_list.append(wsol[:,1])\n",
-    "        I_list.append(wsol[:,2])\n",
-    "        R_list.append(wsol[:,3]) \n",
+    "        wsol = model.solve(tf, numpoints).fetch()\n",
+    "        S_list.append(wsol[:, 1])\n",
+    "        I_list.append(wsol[:, 2])\n",
+    "        R_list.append(wsol[:, 3])\n",
     "    return S_list, I_list, R_list"
    ]
   },
@@ -390,7 +403,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alpha_list = beta*np.array([1.5,1.6,1.7])\n",
+    "alpha_list = beta * np.array([1.5, 1.6, 1.7])\n",
     "S_list, I_list, R_list = compare_infections(my_SIR, tf_long, long_term_days, alpha_list)"
    ]
   },
@@ -400,25 +413,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "col = ['r','b','k']\n",
-    "plt.figure(figsize=[15,5])\n",
+    "col = [\"r\", \"b\", \"k\"]\n",
+    "plt.figure(figsize=[15, 5])\n",
     "for i in range(len(S_list)):\n",
-    "    plt.subplot(1,3,1)\n",
-    "    plt.plot(tspan_long,S_list[i], col[i]+\"--\")\n",
-    "    plt.legend(['R_0 = 1.5','R_0 = 1.6','R_0 = 1.7']) \n",
-    "    plt.xlabel('Days')\n",
-    "    plt.ylabel('Fraction of population')\n",
-    "    plt.title('S')\n",
-    "    plt.subplot(1,3,2)\n",
-    "    plt.plot(tspan_long,I_list[i], col[i])\n",
-    "    plt.legend(['R_0 = 1.5','R_0 = 1.6','R_0 = 1.7']) \n",
-    "    plt.xlabel('Days')\n",
-    "    plt.title('I')\n",
-    "    plt.subplot(1,3,3)\n",
-    "    plt.plot(tspan_long,R_list[i], col[i]+\"-.\")\n",
-    "    plt.legend(['R_0 = 1.5','R_0 = 1.6','R_0 = 1.7']) \n",
-    "    plt.xlabel('Days')\n",
-    "    plt.title('R')\n",
+    "    plt.subplot(1, 3, 1)\n",
+    "    plt.plot(tspan_long, S_list[i], col[i] + \"--\")\n",
+    "    plt.legend([\"R_0 = 1.5\", \"R_0 = 1.6\", \"R_0 = 1.7\"])\n",
+    "    plt.xlabel(\"Days\")\n",
+    "    plt.ylabel(\"Fraction of population\")\n",
+    "    plt.title(\"S\")\n",
+    "    plt.subplot(1, 3, 2)\n",
+    "    plt.plot(tspan_long, I_list[i], col[i])\n",
+    "    plt.legend([\"R_0 = 1.5\", \"R_0 = 1.6\", \"R_0 = 1.7\"])\n",
+    "    plt.xlabel(\"Days\")\n",
+    "    plt.title(\"I\")\n",
+    "    plt.subplot(1, 3, 3)\n",
+    "    plt.plot(tspan_long, R_list[i], col[i] + \"-.\")\n",
+    "    plt.legend([\"R_0 = 1.5\", \"R_0 = 1.6\", \"R_0 = 1.7\"])\n",
+    "    plt.xlabel(\"Days\")\n",
+    "    plt.title(\"R\")\n",
     "\n",
     "plt.show()"
    ]
@@ -484,7 +497,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "MSE = sum(np.sqrt((I_opt-I_UK)**2))/len(I_UK)        \n",
+    "MSE = sum(np.sqrt((I_opt - I_UK) ** 2)) / len(I_UK)\n",
     "print(\"Mean squared error on the model in the train dataset %.2f\" % MSE)"
    ]
   },
@@ -514,7 +527,7 @@
    "source": [
     "# Obtain the results 7 days after the train data ends\n",
     "pred_7 = SIR_UK.predict(7)\n",
-    "print('T n_S \\t   n_I\\t n_R')\n",
+    "print(\"T n_S \\t   n_I\\t n_R\")\n",
     "for i in pred_7:\n",
     "    print(*i.astype(int))"
    ]
@@ -534,10 +547,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import datetime # Import datetime module from the standard library\n",
+    "import datetime  # Import datetime module from the standard library\n",
+    "\n",
     "# Create a date time range based on the number of rows of the prediction\n",
-    "numdays = pred_7.shape[0] \n",
-    "day_zero = datetime.datetime(2020,3,29)\n",
+    "numdays = pred_7.shape[0]\n",
+    "day_zero = datetime.datetime(2020, 3, 29)\n",
     "date_list = [day_zero + datetime.timedelta(days=x) for x in range(numdays)]"
    ]
   },
@@ -548,13 +562,12 @@
    "outputs": [],
    "source": [
     "# Extract figure and axes\n",
-    "fig, ax = plt.subplots(figsize=[5,5])\n",
-    "# plt.plot(pred_7[:,0], pred_7[:,2], linewidth=2)\n",
-    "plt.plot(date_list, pred_7[:,2], linewidth=2)\n",
-    "plt.title('Prediction of UK Cases', size=14)\n",
-    "plt.ylabel('Number of infected', size=14)\n",
+    "fig, ax = plt.subplots(figsize=[5, 5])\n",
+    "plt.plot(date_list, pred_7[:, 2], linewidth=2)\n",
+    "plt.title(\"Prediction of UK Cases\", size=14)\n",
+    "plt.ylabel(\"Number of infected\", size=14)\n",
     "# Remove trailing space\n",
-    "plt.xlim(date_list[0],date_list[-1])\n",
+    "plt.xlim(date_list[0], date_list[-1])\n",
     "# Limit the amount of data displayed\n",
     "ax.xaxis.set_major_locator(plt.MaxNLocator(3))\n",
     "# Increase the size of the ticks\n",
@@ -577,7 +590,7 @@
    "source": [
     "# Get the confidence interval through random bootstrap\n",
     "# Define bootstrap options\n",
-    "options = {\"alpha\":0.95, \"n_iter\":1000, \"r0_ci\":True}\n",
+    "options = {\"alpha\": 0.95, \"n_iter\": 1000, \"r0_ci\": True}\n",
     "# Call bootstrap\n",
     "par_ci, par_list = SIR_UK.ci_bootstrap(**options)"
    ]
@@ -624,25 +637,25 @@
     "# Build numerical solution\n",
     "# I_opt = SIR_UK.solve(n_days-1, n_days).fetch()[:,2]\n",
     "beta_0 = SIR_UK.p[1]\n",
-    "SIR_minus = SIR().set_params([alpha_min, beta_0],n0_UK)\n",
-    "SIR_plus = SIR().set_params([alpha_max, beta_0],n0_UK)\n",
-    "I_minus = SIR_minus.solve(n_days-1, n_days).fetch()[:,2]\n",
-    "I_plus = SIR_plus.solve(n_days-1, n_days).fetch()[:,2]\n",
+    "SIR_minus = SIR().set_params([alpha_min, beta_0], n0_UK)\n",
+    "SIR_plus = SIR().set_params([alpha_max, beta_0], n0_UK)\n",
+    "I_minus = SIR_minus.solve(n_days - 1, n_days).fetch()[:, 2]\n",
+    "I_plus = SIR_plus.solve(n_days - 1, n_days).fetch()[:, 2]\n",
     "\n",
     "# lag = 6\n",
     "\n",
-    "R_opt = SIR_UK.r0 # \n",
+    "R_opt = SIR_UK.r0  #\n",
     "\n",
-    "plt.figure(figsize=[6,6])\n",
-    "plt.plot(t_d,I_UK,'o')\n",
+    "plt.figure(figsize=[6, 6])\n",
+    "plt.plot(t_d, I_UK, \"o\")\n",
     "plt.plot(t_d, I_opt)\n",
     "plt.plot(t_d, I_minus)\n",
     "plt.plot(t_d, I_plus)\n",
-    "plt.legend([\"UK Data\",\"SIR, $R_{0,opt}$ = %.2f\"%R_opt,\"IC_95-\",\"IC_95+\"])\n",
+    "plt.legend([\"UK Data\", \"SIR, $R_{0,opt}$ = %.2f\" % R_opt, \"IC_95-\", \"IC_95+\"])\n",
     "plt.title(\"Fitting of the SIR model against 15 days of UK data\")\n",
     "plt.ylabel(\"Number of people infected\")\n",
     "plt.xlabel(\"Day\")\n",
-    "plt.xlim([min(t_d),max(t_d)])\n",
+    "plt.xlim([min(t_d), max(t_d)])\n",
     "plt.show()"
    ]
   },
@@ -662,9 +675,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.hist(par_list[:,0]/par_list[:,1], bins=50, density=True, stacked=True)\n",
-    "plt.xlabel('$R_0$')\n",
-    "plt.ylabel('Frequency')\n",
+    "plt.hist(par_list[:, 0] / par_list[:, 1], bins=50, density=True, stacked=True)\n",
+    "plt.xlabel(\"$R_0$\")\n",
+    "plt.ylabel(\"Frequency\")\n",
     "plt.title(\"Probability density diagram of $R_0$ bootstrapping\")\n",
     "plt.show()"
    ]
@@ -699,7 +712,7 @@
    "outputs": [],
    "source": [
     "# We previously imported ci_block_cv which provides a better prediction of the mean squared error of the predictions\n",
-    "n_lags=1\n",
+    "n_lags = 1\n",
     "MSE_avg, MSE_list, p_list, pred_data = SIR_UK.block_cv(lags=n_lags, min_sample=3)"
    ]
   },
@@ -745,11 +758,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "print(\"Block cross validation parametric range\")\n",
-    "plt.plot(p_list[:,0],'ro')\n",
+    "plt.plot(p_list[:, 0], \"ro\")\n",
     "plt.title(\"Variation of the parameter alpha through Block CV\")\n",
     "plt.xlabel(\"Days\", size=14)\n",
     "plt.ylabel(\"alpha\", size=14)"
@@ -775,7 +790,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"The average mean squared error on the time cross validation bootstrapping is: %.3f\" % MSE_avg[0])"
+    "print(\n",
+    "    \"\"\"\n",
+    "    The average mean squared error on the time \n",
+    "    block cross validation is: %.3f\"\"\"\n",
+    "    % MSE_avg[0]\n",
+    ")"
    ]
   },
   {
@@ -795,16 +815,16 @@
    },
    "outputs": [],
    "source": [
-    "r0_roll = p_list[:,0]/p_list[:,1]\n",
+    "r0_roll = p_list[:, 0] / p_list[:, 1]\n",
     "\n",
-    "plt.figure(figsize=[10,5])\n",
-    "plt.subplot(1,2,1)\n",
-    "plt.plot(t_d[2:], r0_roll,'ro')\n",
+    "plt.figure(figsize=[10, 5])\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.plot(t_d[2:], r0_roll, \"ro\")\n",
     "plt.xlabel(\"Days used in the block to fit parameters\")\n",
     "plt.ylabel(\"Rolling $R_0$\")\n",
     "plt.title(\"Block bootstrapping change in $R_0$\")\n",
-    "plt.subplot(1,2,2)\n",
-    "plt.plot(t_d[(2):-1], MSE_list[0],'bo')\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.plot(t_d[(2):-1], MSE_list[0], \"bo\")\n",
     "plt.xlabel(\"Days used in the block to fit parameters\")\n",
     "plt.ylabel(\"Mean squared error in number of infected\")\n",
     "plt.title(\"Block bootstrapping change in MSE\")\n",
@@ -859,8 +879,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "e_new = MSE_list[0][-1]/(I_UK[-1]-I_UK[-2])\n",
-    "print(\"The percentage error of the SIR model over the last day reported cases is %.1f%%\" % (100*e_new))"
+    "e_new = MSE_list[0][-1] / (I_UK[-1] - I_UK[-2])\n",
+    "print(\n",
+    "    \"The percentage error of the SIR model over the last day reported cases is %.1f%%\"\n",
+    "    % (100 * e_new)\n",
+    ")"
    ]
   },
   {
@@ -876,7 +899,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eps_avg = np.mean(MSE_list[0]/I_UK[-7:])*100\n",
+    "eps_avg = np.mean(MSE_list[0] / I_UK[-7:]) * 100\n",
     "print(\"The average percentage deviation on the number of infected is %.1f%%\" % eps_avg)"
    ]
   },
@@ -893,8 +916,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "long_time=90\n",
-    "SIR_UK.solve(long_time, long_time+1)\n",
+    "long_time = 90\n",
+    "SIR_UK.solve(long_time, long_time + 1)\n",
     "SIR_UK.plot()"
    ]
   },

--- a/opensir/models/post_regression.py
+++ b/opensir/models/post_regression.py
@@ -307,7 +307,7 @@ class ConfidenceIntervalsMixin:
                 mse_fc.append(mse)
 
         p_list = np.array(p_list)
-        mse_fc = np.array(mse_fc)
+        mse_fc = np.array(mse_fc, dtype=object)
         mse_avg, n_avg, mse_seq = rolling_avg(mse_fc)
 
         # Generate len(t_obs) - min_sample days predictions


### PR DESCRIPTION
### add nb_black (notebook black) code formatter
Following the suggestions of @sasalatart on #82, this PR adds `nb_black` to the Pipfile in order to [automatically format jupyter notebooks](https://medium.com/openplanetary/code-formatting-in-jupyter-cells-8fee4eda072f)

To format jupyter notebook, a magic cell is required before the import statements

```python
%load_ext nb_black
```

Thereafter, the code-formatter automatically format the code in a cell after execution. I updated SIR.ipynb and SIR-X.ipynb notebooks to reflect this change.

Additionally, 6fb5b8b fixes a deprecation warning that was raised on the SIR-X.ipynb notebook (small piggybacking).
